### PR TITLE
Show/Hide obtained collectables in Instance Window

### DIFF
--- a/Collections/Base/Configuration.cs
+++ b/Collections/Base/Configuration.cs
@@ -12,6 +12,7 @@ public class Configuration : IPluginConfiguration
     public List<uint> ArmoireItemIds = new();
     public GlamourTree GlamourTree = new();
     public bool AutoOpenInstanceTab = true;
+    public bool AutoHideObtainedFromInstanceTab = false;
     public bool ForceTryOn = false;
 
     public void Save()

--- a/Collections/UI/Tabs/InstanceTab.cs
+++ b/Collections/UI/Tabs/InstanceTab.cs
@@ -4,6 +4,7 @@ public class InstanceTab : IDrawable
 {
     private Dictionary<string, List<ICollectible>> collections = new();
     private uint collectiblesLoadedInstanceId = 0;
+    private bool hideObtainedCollectables = false;
 
     private EventService EventService { get; init; }
     private CollectionWidget CollectionWidget { get; init; }
@@ -21,6 +22,7 @@ public class InstanceTab : IDrawable
         {
             Services.WindowsInitializer.MainWindow.OpenTab("Instance");
         }
+        hideObtainedCollectables = Services.Configuration.AutoHideObtainedFromInstanceTab;
     }
 
     public void Draw()
@@ -38,6 +40,8 @@ public class InstanceTab : IDrawable
         {
             LoadCollectibles();
         }
+        // Let user hide or show obtained instance collectables
+        ImGui.Checkbox("Hide Obtained", ref hideObtainedCollectables);
 
         // Draw collections
         DrawCollections();
@@ -75,7 +79,10 @@ public class InstanceTab : IDrawable
         foreach (var (name, collection) in collections)
         {
             collections[name] = collection
-                .Where(c => c.CollectibleKey is not null && currentDutyItemIds.Contains(c.CollectibleKey.Id))
+                .Where(
+                    c => c.CollectibleKey is not null
+                    && currentDutyItemIds.Contains(c.CollectibleKey.Id)
+                    && (!hideObtainedCollectables || !c.GetIsObtained()))
                 .ToList();
         }
     }

--- a/Collections/UI/Tabs/InstanceTab.cs
+++ b/Collections/UI/Tabs/InstanceTab.cs
@@ -4,7 +4,7 @@ public class InstanceTab : IDrawable
 {
     private Dictionary<string, List<ICollectible>> collections = new();
     private uint collectiblesLoadedInstanceId = 0;
-    private bool hideObtainedCollectables = false;
+    private bool hideObtainedCollectibles = false;
 
     private EventService EventService { get; init; }
     private CollectionWidget CollectionWidget { get; init; }
@@ -18,7 +18,7 @@ public class InstanceTab : IDrawable
     public void OnDutyStarted(object sender, ushort arg)
     {
         Dev.Log("Received DutyStarted event");
-        hideObtainedCollectables = Services.Configuration.AutoHideObtainedFromInstanceTab;
+        hideObtainedCollectibles = Services.Configuration.AutoHideObtainedFromInstanceTab;
         collectiblesLoadedInstanceId = 0; // Makes sure we always load at the start of an instance
         if (Services.Configuration.AutoOpenInstanceTab)
         {
@@ -41,8 +41,8 @@ public class InstanceTab : IDrawable
         {
             LoadCollectibles();
         }
-        // Let user hide or show obtained instance collectables
-        if(ImGui.Checkbox("Hide Obtained", ref hideObtainedCollectables)) {
+        // Let user hide or show obtained instance collectibles
+        if(ImGui.Checkbox("Hide Obtained", ref hideObtainedCollectibles)) {
             LoadCollectibles();
         };
 
@@ -90,7 +90,7 @@ public class InstanceTab : IDrawable
                         }
                         // Only update items that are part of this instance
                         c.UpdateObtainedState();
-                        return !hideObtainedCollectables || !c.GetIsObtained();
+                        return !hideObtainedCollectibles || !c.GetIsObtained();
                     }
                 )
                 .ToList();

--- a/Collections/UI/Tabs/SettingsTab.cs
+++ b/Collections/UI/Tabs/SettingsTab.cs
@@ -14,6 +14,7 @@ public class SettingsTab : IDrawable
     //};
 
     private bool autoOpenInstanceTab;
+    private bool autoHideObtainedFromInstanceTab;
     public void Draw()
     {
         if (ImGui.Checkbox("Auto open Instance tab when entering an instance", ref autoOpenInstanceTab))
@@ -23,7 +24,7 @@ public class SettingsTab : IDrawable
         }
         if (ImGui.Checkbox("Auto hide obtained items from Instance tab", ref autoHideObtainedFromInstanceTab))
         {
-            Services.Configuration.HideObtainedFromInstanceTab = hideObtainedFromInstanceTab;
+            Services.Configuration.AutoHideObtainedFromInstanceTab = autoHideObtainedFromInstanceTab;
             Services.Configuration.Save();
         }
     }

--- a/Collections/UI/Tabs/SettingsTab.cs
+++ b/Collections/UI/Tabs/SettingsTab.cs
@@ -5,6 +5,7 @@ public class SettingsTab : IDrawable
     public SettingsTab()
     {
         autoOpenInstanceTab = Services.Configuration.AutoOpenInstanceTab;
+        autoHideObtainedFromInstanceTab = Services.Configuration.AutoHideObtainedFromInstanceTab;
     }
 
     //public Dictionary<string, bool> settings = new()
@@ -18,6 +19,11 @@ public class SettingsTab : IDrawable
         if (ImGui.Checkbox("Auto open Instance tab when entering an instance", ref autoOpenInstanceTab))
         {
             Services.Configuration.AutoOpenInstanceTab = autoOpenInstanceTab;
+            Services.Configuration.Save();
+        }
+        if (ImGui.Checkbox("Auto hide obtained items from Instance tab", ref autoHideObtainedFromInstanceTab))
+        {
+            Services.Configuration.HideObtainedFromInstanceTab = hideObtainedFromInstanceTab;
             Services.Configuration.Save();
         }
     }


### PR DESCRIPTION
Adjusted the instance window to show collected status and added a toggle and setting for hiding obtained collectables within the instance window. 

Instance window showing all items:
![Instance window showing all items](https://github.com/user-attachments/assets/058568ef-2903-4ff4-b0b5-dbf225f933e8)

Instance window hiding obtained items:
![Instance window hiding obtained items](https://github.com/user-attachments/assets/82644b73-8522-40d8-bd9f-8b50244ee064)
