### PR TITLE
Misc feature reqs

### DIFF
--- a/Collections/Collectibles/Collectible/Collectible.cs
+++ b/Collections/Collectibles/Collectible/Collectible.cs
@@ -31,7 +31,7 @@ public abstract class Collectible<T> : ICollectible where T : struct, IExcelRow<
         new CollectibleSortOption(
             "Patch", 
             Comparer<ICollectible>.Create((c1, c2) => c2.PatchAdded.CompareTo(c1.PatchAdded)),
-            Icons: (FontAwesomeIcon.SortNumericDown, FontAwesomeIcon.SortNumericUp)
+            Icons: (FontAwesomeIcon.SortNumericDownAlt, FontAwesomeIcon.SortNumericUpAlt)
         ),
         new CollectibleSortOption(
             "Name",

--- a/Collections/Collectibles/Collectible/Collectible.cs
+++ b/Collections/Collectibles/Collectible/Collectible.cs
@@ -39,7 +39,8 @@ public abstract class Collectible<T> : ICollectible where T : struct, IExcelRow<
         ),
         new CollectibleSortOption(
             "Obtained",
-            (c) => c.GetIsObtained()
+            (c) => c.GetIsObtained(),
+            Reverse: true
         )
     ];
     protected List<CollectibleFilterOption> FilterOptions = [

--- a/Collections/Collectibles/Collectible/Collectible.cs
+++ b/Collections/Collectibles/Collectible/Collectible.cs
@@ -30,7 +30,7 @@ public abstract class Collectible<T> : ICollectible where T : struct, IExcelRow<
             "Patch",
             (c) => c.PatchAdded,
             Reverse: true,
-            Icons: (FontAwesomeIcon.SortNumericUpAlt, FontAwesomeIcon.SortNumericDownAlt)
+            Icons: (FontAwesomeIcon.SortNumericDownAlt, FontAwesomeIcon.SortNumericUpAlt)
         ),
         new CollectibleSortOption(
             "Name",

--- a/Collections/Collectibles/Collectible/Collectible.cs
+++ b/Collections/Collectibles/Collectible/Collectible.cs
@@ -8,7 +8,7 @@ public abstract class Collectible<T> : ICollectible where T : struct, IExcelRow<
 {
     public string Name { get; init; }
     public uint Id { get; init; }
-    public string CollectionName;
+    protected virtual string GetCollectionName() => "";
     public abstract void UpdateObtainedState();
     public abstract void Interact();
     public HintModule PrimaryHint { get; init; }
@@ -21,27 +21,25 @@ public abstract class Collectible<T> : ICollectible where T : struct, IExcelRow<
     protected abstract uint GetId();
     protected abstract string GetName();
     protected abstract string GetDescription();
-    protected abstract string GetCollectionName();
 
     public ICollectibleKey CollectibleKey { get; init; }
     public T ExcelRow { get; set; }
     protected IconHandler IconHandler { get; init; }
     protected List<CollectibleSortOption> SortOptions = [
-        // comparing c2 to c1 to modify default sort behavior
         new CollectibleSortOption(
-            "Patch", 
-            Comparer<ICollectible>.Create((c1, c2) => c2.PatchAdded.CompareTo(c1.PatchAdded)),
-            Icons: (FontAwesomeIcon.SortNumericDownAlt, FontAwesomeIcon.SortNumericUpAlt)
+            "Patch",
+            (c) => c.PatchAdded,
+            Reverse: true,
+            Icons: (FontAwesomeIcon.SortNumericUpAlt, FontAwesomeIcon.SortNumericDownAlt)
         ),
         new CollectibleSortOption(
             "Name",
-            Comparer<ICollectible>.Create((c1, c2) => c1.Name.CompareTo(c2.Name)),
+            (c) => c.Name,
             Icons: (FontAwesomeIcon.SortAlphaUp, FontAwesomeIcon.SortAlphaDown)
         ),
-        // comparing c2 to c1 to modify default sort behavior
         new CollectibleSortOption(
             "Obtained",
-            Comparer<ICollectible>.Create((c1, c2) => c2.GetIsObtained().CompareTo(c1.GetIsObtained()))
+            (c) => c.GetIsObtained()
         )
     ];
     protected List<CollectibleFilterOption> FilterOptions = [
@@ -224,5 +222,10 @@ public abstract class Collectible<T> : ICollectible where T : struct, IExcelRow<
     public virtual string GetDisplayPatch()
     {
         return PatchAdded >= 999 ? "Unknown" : PatchAdded.ToString();
+    }
+
+    string ICollectible.GetCollectionName()
+    {
+        return GetCollectionName();
     }
 }

--- a/Collections/Collectibles/Collectible/CollectibleSortOption.cs
+++ b/Collections/Collectibles/Collectible/CollectibleSortOption.cs
@@ -8,6 +8,7 @@ public class CollectibleSortOption
     public CollectibleSortOption(string Name, Func<ICollectible, dynamic> keySelector, bool Reverse = false, (FontAwesomeIcon AscendingIcon, FontAwesomeIcon DescendingIcon)? Icons = null)
     {
         this.Name = Name;
+        this.ReverseDefault = Reverse;
         this.Reverse = Reverse;
         this.GetSortValue = keySelector;
         this.Comparer = Comparer<ICollectible>.Create((c1, c2) => keySelector(c1).CompareTo(keySelector(c2)));
@@ -20,6 +21,8 @@ public class CollectibleSortOption
 
     // name of the sort option
     public string Name { get; set; }
+    // Default setting this sort option was created with for reverse
+    public bool ReverseDefault { get; init; }
     // whether the sorted items should be returned in reverse order
     public bool Reverse { get; set; }
     // how items should be sorted against one another.

--- a/Collections/Collectibles/Collectible/CollectibleSortOption.cs
+++ b/Collections/Collectibles/Collectible/CollectibleSortOption.cs
@@ -34,8 +34,8 @@ public class CollectibleSortOption
     public OrderedParallelQuery<ICollectible> SortCollection(IEnumerable<ICollectible> collection)
     {
         // can't just call reverse, causes the favorites drop down to bottom.
-        if (Reverse) return collection.AsParallel().OrderByDescending(c => c.IsFavorite()).ThenByDescending(c => c, Comparer).ThenByDescending(c => c.Id);
-        return collection.AsParallel().OrderByDescending(c => c.IsFavorite()).ThenBy(c => c, Comparer).ThenBy(c => c.Id);
+        if (Reverse) return collection.AsParallel().OrderByDescending(c => c, Comparer).ThenByDescending(c => c.GetCollectionName()).ThenByDescending(c => c.Id);
+        return collection.AsParallel().OrderBy(c => c, Comparer).ThenBy(c => c.GetCollectionName()).ThenBy(c => c.Id);
     }
 
     public override bool Equals(object? obj)

--- a/Collections/Collectibles/Collectible/CollectibleSortOption.cs
+++ b/Collections/Collectibles/Collectible/CollectibleSortOption.cs
@@ -1,25 +1,31 @@
+using System.Text.RegularExpressions;
 using Collections;
+using FFXIVClientStructs.FFXIV.Common.Lua;
 
 // Provides collections a way to specify ways of sorting 
 public class CollectibleSortOption
 {
-    public CollectibleSortOption(string Name, Comparer<ICollectible> Comparer, bool Reverse = false, (FontAwesomeIcon AscendingIcon, FontAwesomeIcon DescendingIcon)? Icons = null)
+    public CollectibleSortOption(string Name, Func<ICollectible, dynamic> keySelector, bool Reverse = false, (FontAwesomeIcon AscendingIcon, FontAwesomeIcon DescendingIcon)? Icons = null)
     {
         this.Name = Name;
         this.Reverse = Reverse;
-        this.Comparer = Comparer;
-        if(Icons != null)
+        this.GetSortValue = keySelector;
+        this.Comparer = Comparer<ICollectible>.Create((c1, c2) => keySelector(c1).CompareTo(keySelector(c2)));
+        if (Icons != null)
         {
             ascendingIcon = Icons.Value.AscendingIcon;
             descendingIcon = Icons.Value.DescendingIcon;
         }
     }
+
     // name of the sort option
-    public string Name {get; set;}    
+    public string Name { get; set; }
     // whether the sorted items should be returned in reverse order
-    public bool Reverse {get; set;}
+    public bool Reverse { get; set; }
     // how items should be sorted against one another.
-    public Comparer<ICollectible> Comparer {get; set;}
+    public Comparer<ICollectible> Comparer { get; init; }
+    // optional parameter to allow sort options to determine headers when displaying items.
+    public Func<ICollectible, dynamic> GetSortValue { get; init; }
     // optional icon to represent sorting
     private FontAwesomeIcon ascendingIcon = FontAwesomeIcon.SortUp;
     // optional icon to represent reverse sorting
@@ -27,14 +33,14 @@ public class CollectibleSortOption
     public FontAwesomeIcon GetSortIcon() => Reverse ? ascendingIcon : descendingIcon;
     public OrderedParallelQuery<ICollectible> SortCollection(IEnumerable<ICollectible> collection)
     {
-        // can't just call reverse, causes the favorites to drop down to bottom.
-        if(Reverse) return collection.AsParallel().OrderByDescending(c => c.IsFavorite()).ThenByDescending(c => c, Comparer).ThenByDescending(c => c.Id);
+        // can't just call reverse, causes the favorites drop down to bottom.
+        if (Reverse) return collection.AsParallel().OrderByDescending(c => c.IsFavorite()).ThenByDescending(c => c, Comparer).ThenByDescending(c => c.Id);
         return collection.AsParallel().OrderByDescending(c => c.IsFavorite()).ThenBy(c => c, Comparer).ThenBy(c => c.Id);
     }
 
     public override bool Equals(object? obj)
     {
-        if(obj == null || obj.GetType() != this.GetType()) return false;
+        if (obj == null || obj.GetType() != this.GetType()) return false;
         var other = (CollectibleSortOption)obj;
         return this.Name == other.Name && this.ascendingIcon == other.ascendingIcon && this.descendingIcon == other.descendingIcon && this.Reverse == other.Reverse;
     }

--- a/Collections/Collectibles/Collectible/GlamourCollectible.cs
+++ b/Collections/Collectibles/Collectible/GlamourCollectible.cs
@@ -4,13 +4,13 @@ namespace Collections;
 
 public class GlamourCollectible : Collectible<ItemAdapter>, ICreateable<GlamourCollectible, ItemAdapter>
 {
-    public new static string CollectionName => "Glamour";
+    public static string CollectionName => "Glamour";
 
     public GlamourCollectible(ItemAdapter excelRow) : base(excelRow)
     {
-        SortOptions.Add(new CollectibleSortOption("Dye Channels", Comparer<ICollectible>.Create((c1, c2) => ((GlamourCollectible)c1).ExcelRow.DyeCount.CompareTo(((GlamourCollectible)c2).ExcelRow.DyeCount)), true, null));
-        SortOptions.Add(new CollectibleSortOption("Level", Comparer<ICollectible>.Create((c1, c2) => ((GlamourCollectible)c1).ExcelRow.LevelEquip.CompareTo(((GlamourCollectible)c2).ExcelRow.LevelEquip)), false, (FontAwesomeIcon.SortNumericDownAlt, FontAwesomeIcon.SortNumericUpAlt)));
-        SortOptions.Add(new CollectibleSortOption("Model", Comparer<ICollectible>.Create((c1, c2) => ((GlamourCollectible)c1).ExcelRow.ModelMain.CompareTo(((GlamourCollectible)c2).ExcelRow.ModelMain)), false, null));
+        SortOptions.Add(new CollectibleSortOption("Dye Channels", (c) => c is GlamourCollectible ? ((GlamourCollectible)c).ExcelRow.DyeCount : 0));
+        SortOptions.Add(new CollectibleSortOption("Level", (c) => c is GlamourCollectible ? ((GlamourCollectible)c).ExcelRow.LevelEquip : -1, false, (FontAwesomeIcon.SortNumericDownAlt, FontAwesomeIcon.SortNumericUpAlt)));
+        SortOptions.Add(new CollectibleSortOption("Model", (c) => c is GlamourCollectible ? ((GlamourCollectible)c).ExcelRow.ModelMain : 0, false, null));
     }
 
     public static GlamourCollectible Create(ItemAdapter excelRow)

--- a/Collections/Collectibles/Collectible/GlamourCollectible.cs
+++ b/Collections/Collectibles/Collectible/GlamourCollectible.cs
@@ -47,7 +47,7 @@ public class GlamourCollectible : Collectible<ItemAdapter>, ICreateable<GlamourC
     {
         isObtained = Services.ItemFinder.IsItemInInventory(ExcelRow.RowId)
                     || Services.ItemFinder.IsItemInArmoireCache(ExcelRow.RowId)
-                    || Services.ItemFinder.IsItemInDresser(ExcelRow.RowId);
+                    || Services.ItemFinder.IsItemInDresser(ExcelRow.RowId, true);
     }
 
     protected override int GetIconId()

--- a/Collections/Collectibles/Collectible/GlamourCollectible.cs
+++ b/Collections/Collectibles/Collectible/GlamourCollectible.cs
@@ -8,8 +8,8 @@ public class GlamourCollectible : Collectible<ItemAdapter>, ICreateable<GlamourC
 
     public GlamourCollectible(ItemAdapter excelRow) : base(excelRow)
     {
-        SortOptions.Add(new CollectibleSortOption("Dye Channels", (c) => c is GlamourCollectible ? ((GlamourCollectible)c).ExcelRow.DyeCount : 0));
-        SortOptions.Add(new CollectibleSortOption("Level", (c) => c is GlamourCollectible ? ((GlamourCollectible)c).ExcelRow.LevelEquip : -1, false, (FontAwesomeIcon.SortNumericDownAlt, FontAwesomeIcon.SortNumericUpAlt)));
+        SortOptions.Add(new CollectibleSortOption("Dye Channels", (c) => c is GlamourCollectible ? ((GlamourCollectible)c).ExcelRow.DyeCount : -1, true));
+        SortOptions.Add(new CollectibleSortOption("Level", (c) => c is GlamourCollectible ? ((GlamourCollectible)c).ExcelRow.LevelEquip : -1, true, (FontAwesomeIcon.SortNumericDownAlt, FontAwesomeIcon.SortNumericUpAlt)));
         SortOptions.Add(new CollectibleSortOption("Model", (c) => c is GlamourCollectible ? ((GlamourCollectible)c).ExcelRow.ModelMain : 0, false, null));
     }
 

--- a/Collections/Collectibles/Collectible/GlamourCollectible.cs
+++ b/Collections/Collectibles/Collectible/GlamourCollectible.cs
@@ -9,6 +9,7 @@ public class GlamourCollectible : Collectible<ItemAdapter>, ICreateable<GlamourC
     public GlamourCollectible(ItemAdapter excelRow) : base(excelRow)
     {
         SortOptions.Add(new CollectibleSortOption("Dye Channels", Comparer<ICollectible>.Create((c1, c2) => ((GlamourCollectible)c1).ExcelRow.DyeCount.CompareTo(((GlamourCollectible)c2).ExcelRow.DyeCount)), false, null));
+        SortOptions.Add(new CollectibleSortOption("Level", Comparer<ICollectible>.Create((c1, c2) => ((GlamourCollectible)c1).ExcelRow.LevelEquip.CompareTo(((GlamourCollectible)c2).ExcelRow.LevelEquip)), false, null));
         SortOptions.Add(new CollectibleSortOption("Model", Comparer<ICollectible>.Create((c1, c2) => ((GlamourCollectible)c1).ExcelRow.ModelMain.CompareTo(((GlamourCollectible)c2).ExcelRow.ModelMain)), false, null));
     }
 

--- a/Collections/Collectibles/Collectible/GlamourCollectible.cs
+++ b/Collections/Collectibles/Collectible/GlamourCollectible.cs
@@ -8,8 +8,8 @@ public class GlamourCollectible : Collectible<ItemAdapter>, ICreateable<GlamourC
 
     public GlamourCollectible(ItemAdapter excelRow) : base(excelRow)
     {
-        SortOptions.Add(new CollectibleSortOption("Dye Channels", Comparer<ICollectible>.Create((c1, c2) => ((GlamourCollectible)c1).ExcelRow.DyeCount.CompareTo(((GlamourCollectible)c2).ExcelRow.DyeCount)), false, null));
-        SortOptions.Add(new CollectibleSortOption("Level", Comparer<ICollectible>.Create((c1, c2) => ((GlamourCollectible)c1).ExcelRow.LevelEquip.CompareTo(((GlamourCollectible)c2).ExcelRow.LevelEquip)), false, null));
+        SortOptions.Add(new CollectibleSortOption("Dye Channels", Comparer<ICollectible>.Create((c1, c2) => ((GlamourCollectible)c1).ExcelRow.DyeCount.CompareTo(((GlamourCollectible)c2).ExcelRow.DyeCount)), true, null));
+        SortOptions.Add(new CollectibleSortOption("Level", Comparer<ICollectible>.Create((c1, c2) => ((GlamourCollectible)c1).ExcelRow.LevelEquip.CompareTo(((GlamourCollectible)c2).ExcelRow.LevelEquip)), false, (FontAwesomeIcon.SortNumericDownAlt, FontAwesomeIcon.SortNumericUpAlt)));
         SortOptions.Add(new CollectibleSortOption("Model", Comparer<ICollectible>.Create((c1, c2) => ((GlamourCollectible)c1).ExcelRow.ModelMain.CompareTo(((GlamourCollectible)c2).ExcelRow.ModelMain)), false, null));
     }
 

--- a/Collections/Collectibles/Collectible/MountCollectible.cs
+++ b/Collections/Collectibles/Collectible/MountCollectible.cs
@@ -5,11 +5,11 @@ namespace Collections;
 
 public class MountCollectible : Collectible<Mount>, ICreateable<MountCollectible, Mount>
 {
-    public new static string CollectionName => "Mounts";
+    public static string CollectionName => "Mounts";
 
     public MountCollectible(Mount excelRow) : base(excelRow)
     {
-        SortOptions.Add(new CollectibleSortOption("Seats", Comparer<ICollectible>.Create((c1, c2) => ((MountCollectible)c1).ExcelRow.ExtraSeats.CompareTo(((MountCollectible)c2).ExcelRow.ExtraSeats)), false, null));
+        SortOptions.Add(new CollectibleSortOption("Seats", (c) => c is MountCollectible ? ((MountCollectible)c).ExcelRow.ExtraSeats : -1));
     }
 
     public static MountCollectible Create(Mount excelRow)

--- a/Collections/Collectibles/Collectible/OutfitsCollectible.cs
+++ b/Collections/Collectibles/Collectible/OutfitsCollectible.cs
@@ -32,14 +32,12 @@ public class OutfitsCollectible : Collectible<ItemAdapter>, ICreateable<OutfitsC
 
     protected override string GetDescription()
     {
-        return ExcelRow.Description.ToString(); 
+        return ExcelRow.Description.ToString();
     }
 
     public override void UpdateObtainedState()
     {
-        isObtained = Services.ItemFinder.IsItemInInventory(ExcelRow.RowId)
-                    || Services.ItemFinder.IsItemInDresser(ExcelRow.RowId)
-                    || Services.ItemFinder.IsItemInArmoireCache(ExcelRow.RowId);
+        isObtained = Services.ItemFinder.IsItemInDresser(ExcelRow.RowId);
     }
 
     protected override int GetIconId()
@@ -50,36 +48,5 @@ public class OutfitsCollectible : Collectible<ItemAdapter>, ICreateable<OutfitsC
     public override void Interact()
     {
         // Do nothing - taken care of by event service (should probably unify this in some way)
-    }
-    
-    // Internally, outfits and their associated items are stored as 'MirageStoreSetItem'
-    // We can use this to get the items required to create the outfit in the first place.
-    // reason the collection isn't a MirageStoreSetItem is because that class is only a LookupTable,
-    // and it's more convenient to store it internally like a GlamourCollectible.
-    public static List<uint> GetAssociatedItemIds(uint itemId)
-    {
-        List<uint> associatedItems = [];
-        var outfitSet = ExcelCache<MirageStoreSetItem>.GetSheet().GetRow(itemId);
-        if(outfitSet is not null)
-        {
-            var related = outfitSet.Value;
-            // TODO: iterate over, not hardcode
-            associatedItems = [
-                related.MainHand.RowId,
-                related.OffHand.RowId,
-                related.Head.RowId,
-                related.Body.RowId,
-                related.Hands.RowId,
-                related.Legs.RowId,
-                related.Feet.RowId,
-                related.Earrings.RowId,
-                related.Necklace.RowId,
-                related.Bracelets.RowId,
-                related.Ring.RowId,
-            ];
-            associatedItems = associatedItems.Where(id => id != 0).ToList();
-        }
-
-        return associatedItems; 
     }
 }

--- a/Collections/Collectibles/CollectibleKey/OutfitKey.cs
+++ b/Collections/Collectibles/CollectibleKey/OutfitKey.cs
@@ -21,7 +21,7 @@ public class OutfitKey : ItemKey, ICreateable<OutfitKey, (ItemAdapter, int)>
         var dataGenerator = Services.DataGenerator.SourcesDataGenerator;
         
         // get other item IDs
-        var relatedItems = OutfitsCollectible.GetAssociatedItemIds(excelRow.RowId);
+        var relatedItems = Services.ItemFinder.ItemIdsInOutfit(excelRow.RowId);
         bool initializedSources = false;
         foreach(var item in relatedItems)
         {

--- a/Collections/Collectibles/Interfaces/ICollectible.cs
+++ b/Collections/Collectibles/Interfaces/ICollectible.cs
@@ -4,7 +4,7 @@ public interface ICollectible
 {
     public string Name { get; init; }
     public uint Id { get; init; }
-    public decimal PatchAdded {get;init;}
+    public decimal PatchAdded { get; init; }
     public HintModule PrimaryHint { get; init; }
     public HintModule SecondaryHint { get; init; }
     public string Description { get; init; }
@@ -19,7 +19,9 @@ public interface ICollectible
     public ISharedImmediateTexture GetIconLazy();
     public void Interact();
     public string GetDisplayName();
+    public string GetCollectionName();
     public List<CollectibleSortOption> GetSortOptions();
     public List<CollectibleFilterOption> GetFilterOptions();
     public bool GetIsFiltered();
+    public string GetDisplayPatch();
 }

--- a/Collections/Collections.csproj
+++ b/Collections/Collections.csproj
@@ -78,7 +78,7 @@
     <ItemGroup>
         <PackageReference Include="CSVFile" Version="3.2.0" />
         <PackageReference Include="CsvHelper" Version="30.0.1" />
-        <PackageReference Include="LuminaSupplemental.Excel" Version="3.0.1" />
+        <PackageReference Include="LuminaSupplemental.Excel" Version="3.0.4" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <Reference Include="FFXIVClientStructs">
             <HintPath>$(DalamudLibPath)FFXIVClientStructs.dll</HintPath>

--- a/Collections/Data/Providers/DataProvider.cs
+++ b/Collections/Data/Providers/DataProvider.cs
@@ -95,7 +95,6 @@ public class DataProvider
             .ToList()
             );
     }
-
     
     private void InitializeMinionCollection()
     {

--- a/Collections/Data/Providers/DataProvider.cs
+++ b/Collections/Data/Providers/DataProvider.cs
@@ -75,9 +75,6 @@ public class DataProvider
             .Where(entry => SupportedEquipSlots.Contains(entry.EquipSlot))
             .Where(entry => !entry.Name.ToString().StartsWith("Dated ")) // TODO filter only works in English
             .Select(entry => (ICollectible)CollectibleCache<GlamourCollectible, ItemAdapter>.Instance.GetObject(entry))
-            .OrderByDescending(c => c.IsFavorite())
-            .ThenByDescending(c => ((ItemKey)c.CollectibleKey).Input.Item1.LevelEquip)
-            .ThenByDescending(c => c.PatchAdded)
             .ToList()
             );
     }
@@ -90,8 +87,6 @@ public class DataProvider
             ExcelCache<Mount>.GetSheet().AsParallel()
             .Where(entry => entry.Singular != "" && entry.Order != -1)
             .Select(entry => (ICollectible)CollectibleCache<MountCollectible, Mount>.Instance.GetObject(entry))
-            .OrderByDescending(c => c.IsFavorite())
-            .ThenByDescending(c => c.PatchAdded)
             .ToList()
             );
     }
@@ -104,8 +99,6 @@ public class DataProvider
             ExcelCache<Companion>.GetSheet().AsParallel()
             .Where(entry => entry.Singular != "" && !DataOverrides.IgnoreMinionId.Contains(entry.RowId))
             .Select(entry => (ICollectible)CollectibleCache<MinionCollectible, Companion>.Instance.GetObject(entry))
-            .OrderByDescending(c => c.IsFavorite())
-            .ThenByDescending(c => c.PatchAdded)
             .ToList()
             );
     }
@@ -118,8 +111,6 @@ public class DataProvider
             ExcelCache<Emote>.GetSheet().AsParallel()
             .Where(entry => entry.Name != "" && entry.Icon != 0 && !DataOverrides.IgnoreEmoteId.Contains(entry.RowId) && entry.UnlockLink != 0)
             .Select(entry => (ICollectible)CollectibleCache<EmoteCollectible, Emote>.Instance.GetObject(entry))
-            .OrderByDescending(c => c.IsFavorite())
-            .ThenByDescending(c => c.PatchAdded)
             .ToList()
             );
     }
@@ -130,10 +121,8 @@ public class DataProvider
             HairstyleCollectible.CollectionName,
             4,
             ExcelCache<CharaMakeCustomize>.GetSheet().AsParallel()
-            .Where(entry => entry.IsPurchasable && (entry.RowId < 100 || (entry.RowId >= 2050 && entry.RowId < 2100)))
+            .Where(entry => entry.IsPurchasable && (entry.RowId < 100 || (entry.RowId >= 2050 && entry.RowId < 2100)) && (int)entry.Icon != 131094)
             .Select(entry => (ICollectible)CollectibleCache<HairstyleCollectible, CharaMakeCustomize>.Instance.GetObject(entry))
-            .OrderByDescending(c => c.IsFavorite())
-            .ThenByDescending(c => c.PatchAdded)
             .ToList()
             );
     }
@@ -146,8 +135,6 @@ public class DataProvider
             ExcelCache<TripleTriadCard>.GetSheet().AsParallel()
             .Where(entry => entry.Name != "" && entry.Name != "0")
             .Select(entry => (ICollectible)CollectibleCache<TripleTriadCollectible, TripleTriadCard>.Instance.GetObject(entry))
-            .OrderByDescending(c => c.IsFavorite())
-            .ThenByDescending(c => c.PatchAdded)
             .ToList()
             );
     }
@@ -160,8 +147,6 @@ public class DataProvider
             ExcelCache<BuddyEquip>.GetSheet().AsParallel()
             .Where(entry => entry.Name != "" && !DataOverrides.IgnoreBardingId.Contains(entry.RowId))
             .Select(entry => (ICollectible)CollectibleCache<BardingCollectible, BuddyEquip>.Instance.GetObject(entry))
-            .OrderByDescending(c => c.IsFavorite())
-            .ThenByDescending(c => c.PatchAdded)
             .ToList()
             );
     }
@@ -174,8 +159,6 @@ public class DataProvider
             ExcelCache<Lumina.Excel.Sheets.Action>.GetSheet().AsParallel()
             .Where(entry => entry.ClassJob.RowId == 36 && entry.Name != "")
             .Select(entry => (ICollectible)CollectibleCache<BlueMageCollectible, Lumina.Excel.Sheets.Action>.Instance.GetObject(entry))
-            .OrderByDescending(c => c.IsFavorite())
-            .ThenByDescending(c => c.PatchAdded)
             .ToList()
             );
     }
@@ -188,8 +171,6 @@ public class DataProvider
             ExcelCache<Orchestrion>.GetSheet().AsParallel()
             .Where(entry => entry.Name != "" && entry.Name != "0")
             .Select(entry => (ICollectible)CollectibleCache<OrchestrionCollectible, Orchestrion>.Instance.GetObject(entry))
-            .OrderByDescending(c => c.IsFavorite())
-            .ThenByDescending(c => c.Name)
             .ToList()
             );
     }
@@ -203,8 +184,6 @@ public class DataProvider
             .Where(entry => entry.LevelEquip >= 1)
             .Where(entry => entry.ItemUICategory.Value.Name == "Outfits")
             .Select(entry => (ICollectible)CollectibleCache<OutfitsCollectible, ItemAdapter>.Instance.GetObject(entry))
-            .OrderByDescending(c => c.IsFavorite())
-            .ThenByDescending(c => c.PatchAdded)
             .ToList()
             );
     }
@@ -217,8 +196,6 @@ public class DataProvider
             ExcelCache<ItemAdapter>.GetSheet().AsParallel()
             .Where(entry => entry.ItemAction.Value.Type == 29459)
             .Select(entry => (ICollectible)CollectibleCache<FramerKitCollectible, ItemAdapter>.Instance.GetObject(entry))
-            .OrderByDescending(c => c.IsFavorite())
-            .ThenByDescending(c => c.Name)
             .ToList()
             );
     }
@@ -231,8 +208,6 @@ public class DataProvider
             ExcelCache<Ornament>.GetSheet().AsParallel()
             .Where(entry => entry.Icon != 0 && !DataOverrides.IgnoreFashionAccessoryId.Contains(entry.RowId))
             .Select(entry => (ICollectible)CollectibleCache<FashionAccessoriesCollectible, Ornament>.Instance.GetObject(entry))
-            .OrderByDescending(c => c.IsFavorite())
-            .ThenByDescending(c => c.Name)
             .ToList()
             );
     }
@@ -244,8 +219,6 @@ public class DataProvider
             ExcelCache<Glasses>.GetSheet().AsParallel()
             .Where(entry => entry.Icon != 0 && entry.Name == entry.Style.Value.Name)
             .Select(entry => (ICollectible)CollectibleCache<GlassesCollectible, Glasses>.Instance.GetObject(entry))
-            .OrderByDescending(c => c.IsFavorite())
-            .ThenByDescending(c => c.Name)
             .ToList()
             );
     }

--- a/Collections/UI/Events/FilterChangeEvent.cs
+++ b/Collections/UI/Events/FilterChangeEvent.cs
@@ -2,13 +2,28 @@ namespace Collections;
 
 public class FilterChangeEventArgs : EventArgs
 {
-    public FilterChangeEventArgs()
+    public CollectibleStatusFilter? itemStatusFilter = null;
+    public CollectibleSortOption? sortOption = null;
+    public string? searchFilter = null;
+    public FilterChangeEventArgs(
+        CollectibleStatusFilter? itemStatusFilter = null, CollectibleSortOption? sortOptionSelected = null, string? searchFilter = null
+    )
     {
+        this.itemStatusFilter = itemStatusFilter;
+        this.sortOption = sortOptionSelected;
+        this.searchFilter = searchFilter;
     }
+
 }
 
 public class FilterChangeEvent : Event<FilterChangeEventArgs>
 {
 }
 
-
+public enum CollectibleStatusFilter
+{
+    All,
+    Obtained,
+    Unobtained,
+    Favorite,
+}

--- a/Collections/UI/Tabs/CollectionTab.cs
+++ b/Collections/UI/Tabs/CollectionTab.cs
@@ -19,8 +19,7 @@ public class CollectionTab : IDrawable
 
         ContentFiltersWidget = new ContentFiltersWidget(EventService, 1, collection);
         CollectionWidget = new CollectionWidget(EventService, false, false, collection.First().GetSortOptions());
-
-        filteredCollection = collection;
+        ApplyFilters();
         EventService.Subscribe<FilterChangeEvent, FilterChangeEventArgs>(OnPublish);
     }
 

--- a/Collections/UI/Tabs/CollectionTab.cs
+++ b/Collections/UI/Tabs/CollectionTab.cs
@@ -18,7 +18,7 @@ public class CollectionTab : IDrawable
         collectionSize = collection.Count();
 
         ContentFiltersWidget = new ContentFiltersWidget(EventService, 1, collection);
-        CollectionWidget = new CollectionWidget(EventService, false);
+        CollectionWidget = new CollectionWidget(EventService, false, false);
 
         filteredCollection = collection;
         EventService.Subscribe<FilterChangeEvent, FilterChangeEventArgs>(OnPublish);

--- a/Collections/UI/Tabs/CollectionTab.cs
+++ b/Collections/UI/Tabs/CollectionTab.cs
@@ -18,7 +18,7 @@ public class CollectionTab : IDrawable
         collectionSize = collection.Count();
 
         ContentFiltersWidget = new ContentFiltersWidget(EventService, 1, collection);
-        CollectionWidget = new CollectionWidget(EventService, false, false);
+        CollectionWidget = new CollectionWidget(EventService, false, false, collection.First().GetSortOptions());
 
         filteredCollection = collection;
         EventService.Subscribe<FilterChangeEvent, FilterChangeEventArgs>(OnPublish);
@@ -66,6 +66,7 @@ public class CollectionTab : IDrawable
                 contentFilters.Intersect(c.CollectibleKey.SourceCategories).Any() && 
                 // Don't include collectibles that don't have a source populated
                 c.CollectibleKey.SourceCategories.Count != 0))
+            .Where(c => !CollectionWidget.IsFiltered(c))   
             .ToList();
     }
 

--- a/Collections/UI/Tabs/CollectionTab.cs
+++ b/Collections/UI/Tabs/CollectionTab.cs
@@ -18,7 +18,7 @@ public class CollectionTab : IDrawable
         collectionSize = collection.Count();
 
         ContentFiltersWidget = new ContentFiltersWidget(EventService, 1, collection);
-        CollectionWidget = new CollectionWidget(EventService, false, false, collection.First().GetSortOptions());
+        CollectionWidget = new CollectionWidget(EventService, false, collection.First().GetSortOptions());
         ApplyFilters();
         EventService.Subscribe<FilterChangeEvent, FilterChangeEventArgs>(OnPublish);
     }

--- a/Collections/UI/Tabs/CollectionTab.cs
+++ b/Collections/UI/Tabs/CollectionTab.cs
@@ -60,13 +60,13 @@ public class CollectionTab : IDrawable
     private void ApplyFilters()
     {
         var contentFilters = ContentFiltersWidget.Filters.Where(d => d.Value).Select(d => d.Key);
-        filteredCollection = collection.AsParallel()
+        filteredCollection = CollectionWidget.PageSortOption.SortCollection(collection)
             .Where(c => c.CollectibleKey is not null)
             .Where(c => !contentFilters.Any() || (
-                contentFilters.Intersect(c.CollectibleKey.SourceCategories).Any() && 
+                contentFilters.Intersect(c.CollectibleKey.SourceCategories).Any() &&
                 // Don't include collectibles that don't have a source populated
                 c.CollectibleKey.SourceCategories.Count != 0))
-            .Where(c => !CollectionWidget.IsFiltered(c))   
+            .Where(c => !CollectionWidget.IsFiltered(c))
             .ToList();
     }
 

--- a/Collections/UI/Tabs/FullCollectionTab.cs
+++ b/Collections/UI/Tabs/FullCollectionTab.cs
@@ -20,6 +20,7 @@ public class FullCollectionTab : IDrawable
         CollectionWidget = new CollectionWidget(EventService, false, true, Services.DataProvider.GetCollection<MinionCollectible>().First().GetSortOptions());
         ContentFiltersWidget = new ContentFiltersWidget(EventService, 1, filteredCollection);
         EventService.Subscribe<FilterChangeEvent, FilterChangeEventArgs>(OnPublish);
+        ApplyFilters();
     }
 
     public void Draw()

--- a/Collections/UI/Tabs/FullCollectionTab.cs
+++ b/Collections/UI/Tabs/FullCollectionTab.cs
@@ -16,7 +16,8 @@ public class FullCollectionTab : IDrawable
     {
         EventService = new EventService();
         filteredCollection = LoadInitialCollection();
-        CollectionWidget = new CollectionWidget(EventService, false, true, filteredCollection.First().GetSortOptions());
+        // 
+        CollectionWidget = new CollectionWidget(EventService, false, true, Services.DataProvider.GetCollection<MinionCollectible>().First().GetSortOptions());
         ContentFiltersWidget = new ContentFiltersWidget(EventService, 1, filteredCollection);
         EventService.Subscribe<FilterChangeEvent, FilterChangeEventArgs>(OnPublish);
     }

--- a/Collections/UI/Tabs/FullCollectionTab.cs
+++ b/Collections/UI/Tabs/FullCollectionTab.cs
@@ -1,35 +1,99 @@
 
+using System.Collections.Immutable;
+
 namespace Collections;
 
 public class FullCollectionTab : IDrawable
 {
     const int ContentFiltersWidth = 17;
 
-    private List<ICollectible> collections = new();
     private ContentFiltersWidget ContentFiltersWidget { get; init; }
     private CollectionWidget CollectionWidget { get; init; }
     private EventService EventService { get; init; }
+    private decimal? patchSelected = null;
+    Dictionary<decimal, string> patches = new Dictionary<decimal, string>{};
     public FullCollectionTab()
     {
         EventService = new EventService();
-        CollectionWidget = new CollectionWidget(EventService, false, true);
-        collections = Services.DataProvider.GetCollections().Values.Aggregate((full, current) => [.. full, .. current]);
+        filteredCollection = LoadInitialCollection();
+        CollectionWidget = new CollectionWidget(EventService, false, true, filteredCollection.First().GetSortOptions());
+        ContentFiltersWidget = new ContentFiltersWidget(EventService, 1, filteredCollection);
         EventService.Subscribe<FilterChangeEvent, FilterChangeEventArgs>(OnPublish);
     }
 
     public void Draw()
     {
+        var textBaseWidth = ImGui.CalcTextSize("A").X;
+        // Filters
+        ImGui.BeginGroup();
+        ImGui.SetNextItemWidth(textBaseWidth * ContentFiltersWidth);
+        if (ImGui.BeginCombo($"##filterByPatchDropdown", patchSelected == null ? "Select Patch" : patches[patchSelected.Value], ImGuiComboFlags.HeightRegular))
+        {
+            if (ImGui.RadioButton("View All Items", patchSelected == null))
+            {
+                patchSelected = null;
+                ApplyFilters();
+            }
+            foreach (var (patch, displayName) in patches)
+            {
+                bool selected = patchSelected == patch;
+                if (ImGui.RadioButton(displayName, selected))
+                {
+                    patchSelected = patch;
+                    ApplyFilters();
+                }
+            }
+            ImGui.EndCombo();
+        }
+        if (ImGui.BeginTable("filters-widget", 1, ImGuiTableFlags.Borders | ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.NoHostExtendX))
+        {
+            ImGui.TableSetupColumn("Content Filters", ImGuiTableColumnFlags.None, textBaseWidth * ContentFiltersWidth);
+            ImGui.TableHeadersRow();
+
+            ImGui.TableNextRow(ImGuiTableRowFlags.None, UiHelper.GetLengthToBottomOfWindow());
+            ImGui.TableNextColumn();
+            ContentFiltersWidget.Draw();
+            ImGui.EndTable();
+        }
+        ImGui.EndGroup();
+
+        // Glam collection
+        ImGui.SameLine();
+        ImGui.BeginChild("collection");
         // Draw collections
         DrawCollections();
+        ImGui.EndChild();
     }
 
     public void DrawCollections()
     {
-        CollectionWidget.Draw(collections, enableFilters: true);
+        CollectionWidget.Draw(filteredCollection, enableFilters: true);
     }
+
     public void OnPublish(FilterChangeEventArgs args)
     {
-        
+        ApplyFilters();
+    }
+
+    private List<ICollectible> filteredCollection { get; set; }
+    private void ApplyFilters()
+    {
+        // Not going to store 2 lists. Just pull new one on change.
+        var contentFilters = ContentFiltersWidget.Filters.Where(d => d.Value).Select(d => d.Key);
+        filteredCollection = CollectionWidget.PageSortOption.SortCollection(LoadInitialCollection())
+            .Where(c => c.CollectibleKey is not null)
+            .Where(c => !contentFilters.Any() || (
+                contentFilters.Intersect(c.CollectibleKey.SourceCategories).Any() &&
+                // Don't include collectibles that don't have a source populated
+                c.CollectibleKey.SourceCategories.Count != 0))
+            .Where(c => (patchSelected == null) || (c.PatchAdded == (decimal)patchSelected))
+            .Where(c => !CollectionWidget.IsFiltered(c))
+            .ToList();
+    }
+
+    private List<ICollectible> LoadInitialCollection()
+    {
+        return Services.DataProvider.GetCollections().Values.Aggregate((full, current) => [.. full, .. current]);
     }
 
     public void OnOpen()
@@ -38,10 +102,12 @@ public class FullCollectionTab : IDrawable
 
         Task.Run(() =>
         {
-            foreach (var collectible in collections)
+            foreach (var collectible in filteredCollection)
             {
                 collectible.UpdateObtainedState();
+                patches[collectible.PatchAdded] = collectible.GetDisplayPatch();
             }
+            patches = patches.AsParallel().OrderByDescending((p) => p.Key).ToDictionary();
         });
     }
 

--- a/Collections/UI/Tabs/FullCollectionTab.cs
+++ b/Collections/UI/Tabs/FullCollectionTab.cs
@@ -1,0 +1,56 @@
+
+namespace Collections;
+
+public class FullCollectionTab : IDrawable
+{
+    const int ContentFiltersWidth = 17;
+
+    private List<ICollectible> collections = new();
+    private ContentFiltersWidget ContentFiltersWidget { get; init; }
+    private CollectionWidget CollectionWidget { get; init; }
+    private EventService EventService { get; init; }
+    public FullCollectionTab()
+    {
+        EventService = new EventService();
+        CollectionWidget = new CollectionWidget(EventService, false, true);
+        collections = Services.DataProvider.GetCollections().Values.Aggregate((full, current) => [.. full, .. current]);
+        EventService.Subscribe<FilterChangeEvent, FilterChangeEventArgs>(OnPublish);
+    }
+
+    public void Draw()
+    {
+        // Draw collections
+        DrawCollections();
+    }
+
+    public void DrawCollections()
+    {
+        CollectionWidget.Draw(collections, enableFilters: true);
+    }
+    public void OnPublish(FilterChangeEventArgs args)
+    {
+        
+    }
+
+    public void OnOpen()
+    {
+        Dev.Log();
+
+        Task.Run(() =>
+        {
+            foreach (var collectible in collections)
+            {
+                collectible.UpdateObtainedState();
+            }
+        });
+    }
+
+    public void OnClose()
+    {
+    }
+
+    public void Dispose()
+    {
+    }
+}
+

--- a/Collections/UI/Tabs/FullCollectionTab.cs
+++ b/Collections/UI/Tabs/FullCollectionTab.cs
@@ -17,7 +17,7 @@ public class FullCollectionTab : IDrawable
         EventService = new EventService();
         filteredCollection = LoadInitialCollection();
         // 
-        CollectionWidget = new CollectionWidget(EventService, false, true, Services.DataProvider.GetCollection<MinionCollectible>().First().GetSortOptions());
+        CollectionWidget = new CollectionWidget(EventService, false, Services.DataProvider.GetCollection<MinionCollectible>().First().GetSortOptions());
         ContentFiltersWidget = new ContentFiltersWidget(EventService, 1, filteredCollection);
         EventService.Subscribe<FilterChangeEvent, FilterChangeEventArgs>(OnPublish);
         ApplyFilters();

--- a/Collections/UI/Tabs/GlamourTab.cs
+++ b/Collections/UI/Tabs/GlamourTab.cs
@@ -18,7 +18,7 @@ public class GlamourTab : IDrawable
         ContentFiltersWidget = new ContentFiltersWidget(EventService, 2);
         EquipSlotsWidget = new EquipSlotsWidget(EventService);
         filteredCollection = GetInitialCollection();
-        CollectionWidget = new CollectionWidget(EventService, true, false, GetInitialCollection().First().GetSortOptions());
+        CollectionWidget = new CollectionWidget(EventService, true, GetInitialCollection().First().GetSortOptions());
 
         ApplyFilters();
 

--- a/Collections/UI/Tabs/GlamourTab.cs
+++ b/Collections/UI/Tabs/GlamourTab.cs
@@ -18,7 +18,7 @@ public class GlamourTab : IDrawable
         JobSelectorWidget = new JobSelectorWidget(EventService);
         ContentFiltersWidget = new ContentFiltersWidget(EventService, 2);
         EquipSlotsWidget = new EquipSlotsWidget(EventService);
-        CollectionWidget = new CollectionWidget(EventService, true);
+        CollectionWidget = new CollectionWidget(EventService, true, false);
 
         ApplyFilters();
 
@@ -133,8 +133,6 @@ public class GlamourTab : IDrawable
     {
         Dev.Log();
 
-        CollectionWidget.ResetDynamicScrolling();
-
         Task.Run(() =>
         {
             foreach (var collectible in Services.DataProvider.GetCollection<GlamourCollectible>())
@@ -146,9 +144,6 @@ public class GlamourTab : IDrawable
 
     private void ApplyFilters()
     {
-        // Refresh dynamic scrolling
-        CollectionWidget.ResetDynamicScrolling();
-
         // Refresh all filteres (1) Equip slot (2) content type (3) job
         var contentFilters = ContentFiltersWidget.Filters.Where(d => d.Value).Select(d => d.Key);
         var jobFilters = JobSelectorWidget.Filters.Where(d => d.Value).Select(d => d.Key).ToList();

--- a/Collections/UI/Tabs/InstanceTab.cs
+++ b/Collections/UI/Tabs/InstanceTab.cs
@@ -11,7 +11,7 @@ public class InstanceTab : IDrawable
     public InstanceTab()
     {
         EventService = new EventService();
-        CollectionWidget = new CollectionWidget(EventService, false);
+        CollectionWidget = new CollectionWidget(EventService, false, true);
         Services.DutyState.DutyStarted += OnDutyStarted;
     }
 
@@ -35,7 +35,6 @@ public class InstanceTab : IDrawable
             collectiblesLoadedInstanceId = 0;
             return;
         }
-
         // Load collectibles if not done already
         if (GetCurrentInstance() != collectiblesLoadedInstanceId)
         {
@@ -52,22 +51,19 @@ public class InstanceTab : IDrawable
 
     public void DrawCollections()
     {
+        List<ICollectible> merged = [];
         foreach (var (name, collection) in collections)
         {
-            if (collection.Any())
+            // Save glam for last row
+            if (name == GlamourCollectible.CollectionName)
             {
-                // Save glam for last row
-                if (name == GlamourCollectible.CollectionName)
-                {
-                    continue;
-                }
-                CollectionWidget.Draw(collection, true, false, name);
+                continue;
             }
+            merged.AddRange(collection);
         }
         if (collections.ContainsKey(GlamourCollectible.CollectionName))
-        {
-            CollectionWidget.Draw(collections[GlamourCollectible.CollectionName], true, false, GlamourCollectible.CollectionName);
-        }
+            merged.AddRange(collections[GlamourCollectible.CollectionName]);
+        CollectionWidget.Draw(merged, enableFilters: false, enableCollectionHeaders: true);
     }
 
     private void LoadCollectibles()

--- a/Collections/UI/Tabs/InstanceTab.cs
+++ b/Collections/UI/Tabs/InstanceTab.cs
@@ -61,15 +61,12 @@ public class InstanceTab : IDrawable
                 {
                     continue;
                 }
-                ImGui.Selectable(name);
-                CollectionWidget.Draw(collection, false, false);
+                CollectionWidget.Draw(collection, true, false, name);
             }
         }
-
         if (collections.ContainsKey(GlamourCollectible.CollectionName))
         {
-            ImGui.Selectable(GlamourCollectible.CollectionName);
-            CollectionWidget.Draw(collections[GlamourCollectible.CollectionName], false, false);
+            CollectionWidget.Draw(collections[GlamourCollectible.CollectionName], true, false, GlamourCollectible.CollectionName);
         }
     }
 

--- a/Collections/UI/Tabs/InstanceTab.cs
+++ b/Collections/UI/Tabs/InstanceTab.cs
@@ -24,6 +24,7 @@ public class InstanceTab : IDrawable
         {
             Services.WindowsInitializer.MainWindow.OpenTab("Instance");
         }
+
     }
 
     public void Draw()
@@ -61,10 +62,13 @@ public class InstanceTab : IDrawable
 
         collections =
         Services.DataProvider.GetCollections().Values.Aggregate(
-            (full, col) => [..full, ..col.Where((c) => 
+            (full, col) => [..full, ..col]).Where((c) => 
                 {
                     // TODO: blue mage spells don't come from items.
-                    if(c.GetCollectionName() == BlueMageCollectible.CollectionName) return false;
+                    if(c.GetCollectionName() == BlueMageCollectible.CollectionName) {
+                        Dev.Log($"{c.GetCollectionName() == BlueMageCollectible.CollectionName}");
+                        return false;
+                    }
                     if ((c.CollectibleKey is not null) && ((c.CollectibleKey.Id == 0) || (!currentDutyItemIds.Contains(c.CollectibleKey.Id))))
                     {
                         return false;
@@ -73,9 +77,9 @@ public class InstanceTab : IDrawable
                     c.UpdateObtainedState();
                     return !hideObtainedCollectibles || !c.GetIsObtained();
                 }
-            )])
+            )
         // put glamour as last 
-        .OrderBy(c => c.GetCollectionName() != GlamourCollectible.CollectionName)
+        .OrderBy(c => c.GetCollectionName() == GlamourCollectible.CollectionName)
         .ToList();
     }
 

--- a/Collections/UI/Tabs/InstanceTab.cs
+++ b/Collections/UI/Tabs/InstanceTab.cs
@@ -11,7 +11,7 @@ public class InstanceTab : IDrawable
     public InstanceTab()
     {
         EventService = new EventService();
-        CollectionWidget = new CollectionWidget(EventService, false, true);
+        CollectionWidget = new CollectionWidget(EventService, false);
         Services.DutyState.DutyStarted += OnDutyStarted;
     }
 

--- a/Collections/UI/Tabs/InstanceTab.cs
+++ b/Collections/UI/Tabs/InstanceTab.cs
@@ -66,7 +66,6 @@ public class InstanceTab : IDrawable
                 {
                     // TODO: blue mage spells don't come from items.
                     if(c.GetCollectionName() == BlueMageCollectible.CollectionName) {
-                        Dev.Log($"{c.GetCollectionName() == BlueMageCollectible.CollectionName}");
                         return false;
                     }
                     if ((c.CollectibleKey is not null) && ((c.CollectibleKey.Id == 0) || (!currentDutyItemIds.Contains(c.CollectibleKey.Id))))

--- a/Collections/UI/Tabs/WishlistTab.cs
+++ b/Collections/UI/Tabs/WishlistTab.cs
@@ -9,7 +9,7 @@ public class WishlistTab : IDrawable
     public WishlistTab()
     {
         EventService = new EventService();
-        CollectionWidget = new CollectionWidget(EventService, false, true);
+        CollectionWidget = new CollectionWidget(EventService, false);
         LoadCollectibles();
 
         EventService.Subscribe<FilterChangeEvent, FilterChangeEventArgs>(OnPublish);

--- a/Collections/UI/Tabs/WishlistTab.cs
+++ b/Collections/UI/Tabs/WishlistTab.cs
@@ -2,7 +2,7 @@ namespace Collections;
 
 public class WishlistTab : IDrawable
 {
-    private Dictionary<string, List<ICollectible>> collections = new();
+    private List<ICollectible> collections = new();
 
     private EventService EventService { get; init; }
     private CollectionWidget CollectionWidget { get; init; }
@@ -17,30 +17,19 @@ public class WishlistTab : IDrawable
 
     public void Draw()
     {
-        List<ICollectible> merged = [];
-        foreach (var (name, collection) in collections) {
-            if (collection.Any())
-            {
-                merged.AddRange(collection);
-            }
-        }
-        if (merged.Count == 0)
+        if (collections.Count == 0)
         {
             ImGui.Text("No items in Wish List");
         }
         else
         {
-            CollectionWidget.Draw(merged, enableFilters: false, enableCollectionHeaders: true);
+            CollectionWidget.Draw(collections, enableFilters: false, enableCollectionHeaders: true);
         }
     }
 
     private void LoadCollectibles()
     {
-        collections = Services.DataProvider.GetCollections();
-        foreach (var (name, collection) in collections)
-        {
-            collections[name] = collection.Where(c => c.IsWishlist()).ToList();
-        }
+        collections = Services.DataProvider.GetCollections().Values.Aggregate((full, c) => [..full, ..c]).Where(c => c.IsWishlist()).ToList();
     }
 
     public void OnPublish(FilterChangeEventArgs args)

--- a/Collections/UI/Tabs/WishlistTab.cs
+++ b/Collections/UI/Tabs/WishlistTab.cs
@@ -36,7 +36,6 @@ public class WishlistTab : IDrawable
 
     private void LoadCollectibles()
     {
-        Dev.Log("Loading wish list collectibles");
         collections = Services.DataProvider.GetCollections();
         foreach (var (name, collection) in collections)
         {

--- a/Collections/UI/Tabs/WishlistTab.cs
+++ b/Collections/UI/Tabs/WishlistTab.cs
@@ -17,18 +17,16 @@ public class WishlistTab : IDrawable
 
     public void Draw()
     {
-        var isEmpty = true;
+        bool empty = true;
         foreach (var (name, collection) in collections)
         {
             if (collection.Any())
             {
-                ImGui.Selectable(name);
-                CollectionWidget.Draw(collection, false, false);
-                isEmpty = false;
+                CollectionWidget.Draw(collection, true, false, name);
+                empty = false; 
             }
         }
-
-        if (isEmpty)
+        if (empty)
         {
             ImGui.Text("No items in Wish List");
         }

--- a/Collections/UI/Tabs/WishlistTab.cs
+++ b/Collections/UI/Tabs/WishlistTab.cs
@@ -9,7 +9,7 @@ public class WishlistTab : IDrawable
     public WishlistTab()
     {
         EventService = new EventService();
-        CollectionWidget = new CollectionWidget(EventService, false);
+        CollectionWidget = new CollectionWidget(EventService, false, true);
         LoadCollectibles();
 
         EventService.Subscribe<FilterChangeEvent, FilterChangeEventArgs>(OnPublish);
@@ -17,18 +17,20 @@ public class WishlistTab : IDrawable
 
     public void Draw()
     {
-        bool empty = true;
-        foreach (var (name, collection) in collections)
-        {
+        List<ICollectible> merged = [];
+        foreach (var (name, collection) in collections) {
             if (collection.Any())
             {
-                CollectionWidget.Draw(collection, true, false, name);
-                empty = false; 
+                merged.AddRange(collection);
             }
         }
-        if (empty)
+        if (merged.Count == 0)
         {
             ImGui.Text("No items in Wish List");
+        }
+        else
+        {
+            CollectionWidget.Draw(merged, enableFilters: false, enableCollectionHeaders: true);
         }
     }
 

--- a/Collections/UI/Widgets/CollectionWidget.cs
+++ b/Collections/UI/Widgets/CollectionWidget.cs
@@ -10,10 +10,9 @@ public class CollectionWidget
     public CollectibleSortOption PageSortOption { get; set; }
     private List<CollectibleSortOption> cachedOptions = [];
     private bool isGlam { get; init; } = false;
-    private bool isMulti { get; init; } = false;
     private EventService EventService { get; init; }
     private TooltipWidget CollectibleTooltipWidget { get; init; }
-    public CollectionWidget(EventService eventService, bool isGlam, bool isMultiCollection, List<CollectibleSortOption>? collectibleSortOptions = null)
+    public CollectionWidget(EventService eventService, bool isGlam, List<CollectibleSortOption>? collectibleSortOptions = null)
     {
         EventService = eventService;
         this.isGlam = isGlam;

--- a/Collections/UI/Widgets/CollectionWidget.cs
+++ b/Collections/UI/Widgets/CollectionWidget.cs
@@ -22,7 +22,7 @@ public class CollectionWidget
 
     private int dynamicScrollingCurrentSize;
     private int obtainedState = 0;
-    public unsafe void Draw(List<ICollectible> collectionList, bool expandAvailableRegion = true, bool enableFilters = true)
+    public unsafe void Draw(List<ICollectible> collectionList, bool expandAvailableRegion = true, bool enableFilters = true, string? collectionHeader = null)
     {
         // Draw filters
         if (enableFilters)
@@ -31,6 +31,7 @@ public class CollectionWidget
             // Sort by user selection
             collectionList = PageSortOption.SortCollection(collectionList).ToList();
         }
+        
         // Expand child on remaining window space
         if (expandAvailableRegion)
         {
@@ -49,6 +50,12 @@ public class CollectionWidget
 
         drawItemCount = 0;
         var iconsPerRow = GetIconsPerRow();
+
+            // Add header
+        if (collectionHeader != null)
+        {
+            ImGui.Selectable(collectionHeader);
+        }
 
         for (var i = 0; i < collectionList.Count; i++)
         {

--- a/Collections/UI/Windows/MainWindow.cs
+++ b/Collections/UI/Windows/MainWindow.cs
@@ -8,7 +8,7 @@ public class MainWindow : Window, IDisposable
 
     private List<(string name, IDrawable window)> tabs { get; init; }
 
-    public MainWindow() : base("Collections", ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoCollapse)
+    public MainWindow() : base("Collections", ImGuiWindowFlags.NoScrollbar)
     {
         StoreOriginalColors();
 

--- a/Collections/UI/Windows/MainWindow.cs
+++ b/Collections/UI/Windows/MainWindow.cs
@@ -21,6 +21,7 @@ public class MainWindow : Window, IDisposable
         tabs = GetCollectionTabs();
         var additionalTabs = new List<(string name, IDrawable window)>()
         {
+            ("All Items", new FullCollectionTab()),
             ("Instance",  new InstanceTab()),
             ("Wish List", new WishlistTab()),
             ("Settings", new SettingsTab()),

--- a/Collections/UI/Windows/MainWindow.cs
+++ b/Collections/UI/Windows/MainWindow.cs
@@ -76,12 +76,6 @@ public class MainWindow : Window, IDisposable
     {
         if (T == typeof(GlamourCollectible))
             return new GlamourTab();
-        // else if(T == typeof(FashionAccessoriesCollectible) || T == typeof(GlassesCollectible))
-        // {
-        //     var combinedAccessories = Services.DataProvider.GetCollection(typeof(FashionAccessoriesCollectible));
-        //     combinedAccessories.AddRange(Services.DataProvider.GetCollection(typeof(GlassesCollectible)));
-        //     return new CollectionTab(combinedAccessories);
-        // }
         else
             return new CollectionTab(Services.DataProvider.GetCollection(T));
 

--- a/Collections/packages.lock.json
+++ b/Collections/packages.lock.json
@@ -28,9 +28,9 @@
       },
       "LuminaSupplemental.Excel": {
         "type": "Direct",
-        "requested": "[3.0.1, )",
-        "resolved": "3.0.1",
-        "contentHash": "IzDLupuqO3ylTdKPn0RLEpmV1ealToK11KxoMFNYJBEQGUpUOwa5B6704dlEwUUsqXs0vKNt3wfuvAKol4S1bQ==",
+        "requested": "[3.0.4, )",
+        "resolved": "3.0.4",
+        "contentHash": "arwlsVOOmRVZK0geHdzQLK0R5l/3IRg13Vne0ROlTelmSCesS7ExZoHaleSDcSzhRTV7+U/ZXDTVGlxPeZAu+w==",
         "dependencies": {
           "CSVFile": "3.2.0",
           "CsvHelper": "30.0.1",


### PR DESCRIPTION
- Added sort option for level to glamour collectibles ( #37 )
- Scrollbar shows up automatically when items would be rendered off screen for wishlist and instance tabs ( #38 )
- Removed "No Collapse" flag, unable to crash or cause any issues in testing ( #32 )
- Fixed issue where obtained glamour items would not show as obtained if stored within an outfit ( #41 )
<img width="767" height="161" alt="image" src="https://github.com/user-attachments/assets/e4e0051b-b17a-4496-b098-ec8997b7b1c1" />

- Implemented "All Items" tab ( #34 )
   - Able to select specific patch via left-hand dropdown

<img width="1436" height="999" alt="image" src="https://github.com/user-attachments/assets/1768b89f-9dc3-4b45-a5bf-614c54be56e5" />
<img width="1442" height="1000" alt="image" src="https://github.com/user-attachments/assets/a223f877-26d5-4e9d-b718-8774bb77a77f" />

- Improved rendering performance via ListClipper and re-organizing code calls
   - previous render time per call (Glamour Tab): 6-7ms (60000-70000 ticks)
<img width="804" height="67" alt="image" src="https://github.com/user-attachments/assets/5fbef902-6272-4401-bfab-bc59f7c1ef14" />

   - new render time per call (Glamour Tab): 0.5ms (5000 ticks), 1.3ms on filter change event (13000 ticks) 
<img width="796" height="69" alt="image" src="https://github.com/user-attachments/assets/4383a116-2d73-4849-bb5a-a44c77a13da5" />

- Added option to automatically draw collection headers on merged collections
   - Due to ListClipper limitations, falls back to previous performance and should only be used on small collections
- Fixed issue with unimplemented hair collectible causing display issues
- **Opinionated Change**: Favorites no longer show up at the top of a collection. Instead, filter added to show only favorite items in collection. Benefits of this change are faster sort times for all collections and easier programmatic implementation of nested collection headers. As personal preference, I always thought it was jarring having an item I favorite within a list just jump to the top because of an implicit 'sorting rule'.
<img width="1275" height="330" alt="image" src="https://github.com/user-attachments/assets/bd989b21-1550-40ab-ab84-e1d861bf71b0" />
