### PR TITLE
Fixing "Duty" source filter not working

### DIFF
--- a/Collections/Collectibles/CollectibleSource/InstanceSource.cs
+++ b/Collections/Collectibles/CollectibleSource/InstanceSource.cs
@@ -15,7 +15,7 @@ public class InstanceSource : CollectibleSource
         return ContentFinderConditionInternal.Name.ToString();
     }
 
-    private List<SourceCategory> sourceType = [];
+    private List<SourceCategory> sourceType;
     public override List<SourceCategory> GetSourceCategories()
     {
         if (sourceType != null)


### PR DESCRIPTION
Hi

The duty filter button doesn't work which seems to be a known bug and was marked as a limitation of breaking changes in LuminaSupplemental. However it seems to work fine if we remove the property assignment added by [this commit](https://github.com/seventhxiv/Collections/commit/5d82e4415c0a6901c661d597612891d33b3f091b#diff-4807247e6d1b2b60b867418f2c48c2bd06639a0e2276a990a8a7a977ac84ff89R17-R18)

I'm new to Github and also to XIV Modding so I apologize in advance if I'm missing obvious things.

Thanks for this great plugin too, it's one of my favorites!
