### PR TITLE
Migrate to Dalamud API 15

### DIFF
--- a/Collections/Base/Services.cs
+++ b/Collections/Base/Services.cs
@@ -7,6 +7,7 @@ public class Services
 {
     [PluginService] public static IDalamudPluginInterface PluginInterface { get; private set; }
     [PluginService] public static IClientState ClientState { get; private set; }
+    [PluginService] public static IObjectTable ObjectTable { get; private set; }
     [PluginService] public static IUnlockState UnlockState { get; private set; }
     [PluginService] public static IPlayerState PlayerState { get; private set; }
     [PluginService] public static ICommandManager CommandManager { get; private set; }

--- a/Collections/Collectibles/Collectible/FramerKitCollectible.cs
+++ b/Collections/Collectibles/Collectible/FramerKitCollectible.cs
@@ -42,9 +42,7 @@ public class FramerKitCollectible : Collectible<BannerCondition>, ICreateable<Fr
         var misc = ExcelCache<CharaCardDecoration>.GetSheet().Where(row => row.UnlockCondition.RowId == excelRow.RowId).ToList();
         foreach(var decal in misc)
         {
-            // TODO: Uncomment once my dev environment can actually build with the proper label for the new EXDSheets
-            // switch(decal.Component)
-            switch(decal.Unknown2)
+            switch(decal.Component)
             {
                 case 1:
                     PlateBacking = decal.RowId;

--- a/Collections/Collectibles/Collectible/GlamourCollectible.cs
+++ b/Collections/Collectibles/Collectible/GlamourCollectible.cs
@@ -16,9 +16,9 @@ public class GlamourCollectible : Collectible<Item>, ICreateable<GlamourCollecti
             (c) => {
                 if(c.Item1 is GlamourCollectible)
                 {
-                    bool exclude = (c.Item1 as GlamourCollectible).ExcelRow.EquipRestriction > 1 && 
+                    bool exclude = (c.Item1 as GlamourCollectible).ExcelRow.EquipRestriction.RowId > 1 &&
                     // Modulus of the equip restriction gives if it's exclusive to male or female
-                    (c.Item1 as GlamourCollectible).ExcelRow.EquipRestriction % 2 == (c.Item2 < 100 ? c.Item2 % 2 : c.Item2 - 102);
+                    (c.Item1 as GlamourCollectible).ExcelRow.EquipRestriction.RowId % 2 == (c.Item2 < 100 ? c.Item2 % 2 : c.Item2 - 102);
                     // Flip result if going male/female only
                     if(c.Item2 > 100) exclude = !exclude;
                     return exclude;

--- a/Collections/Collections.csproj
+++ b/Collections/Collections.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Dalamud.NET.Sdk/14.0.2">
+<Project Sdk="Dalamud.NET.Sdk/15.0.0">
     <PropertyGroup>
         <Version>1.0.3.1</Version>
         <Description>Collections</Description>

--- a/Collections/Data/Generators/Sources/EventDataGenerator.cs
+++ b/Collections/Data/Generators/Sources/EventDataGenerator.cs
@@ -49,7 +49,7 @@ public class EventDataGenerator : BaseDataGenerator<string>
         {
             if (quest.Id.ToString().StartsWith(entry.Key))
             {
-                return ExcelCache<FittingShopCategory>.GetSheet().GetRow(entry.Value).GetValueOrDefault().Unknown0.ToString() ?? fallback;
+                return ExcelCache<FittingShopCategory>.GetSheet().GetRow(entry.Value).GetValueOrDefault().Name.ToString() ?? fallback;
             }
         }
         // try lookup as armoire sub category (harder)

--- a/Collections/Data/Generators/Sources/MogStationDataGenerator.cs
+++ b/Collections/Data/Generators/Sources/MogStationDataGenerator.cs
@@ -29,7 +29,7 @@ public class MogStationDataGenerator : BaseDataGenerator<uint>
         {
             foreach (var subRow in FittingShopCategoryItem)
             {
-                var itemId = Convert.ToUInt32(subRow.Unknown0);
+                var itemId = subRow.Item.RowId;
                 AddEntry(itemId, 0);
             }
         }

--- a/Collections/Data/Providers/DresserObserver.cs
+++ b/Collections/Data/Providers/DresserObserver.cs
@@ -89,7 +89,7 @@ public unsafe class DresserObserver
         var cabinetSheet = ExcelCache<Lumina.Excel.Sheets.Cabinet>.GetSheet();
         foreach (var cabinet in cabinetSheet)
         {
-            if (Cabinet.IsItemInCabinet((int)cabinet.RowId))
+            if (Cabinet.IsItemInCabinet(cabinet.RowId))
             {
                 var itemId = (uint)Services.ItemFinder.ItemIdFromCabinetId(cabinet.RowId);
                 ArmoireItemIds.Add(itemId);

--- a/Collections/Executors/PreviewExecutor.cs
+++ b/Collections/Executors/PreviewExecutor.cs
@@ -7,7 +7,7 @@ namespace Collections;
 public unsafe class PreviewExecutor
 {
     private HashSet<EquipSlot> previewHistory = new();
-    private static Character* Character = (Character*)Services.ClientState.LocalPlayer.Address;
+    private static Character* Character = (Character*)Services.ObjectTable.LocalPlayer.Address;
 
     public static bool IsInGPose()
     {

--- a/Collections/Executors/PreviewExecutor.cs
+++ b/Collections/Executors/PreviewExecutor.cs
@@ -161,7 +161,7 @@ public unsafe class PreviewExecutor
     private void PreviewWeapon(EquipSlot equipSlot, WeaponModelId weaponModelId)
     {
         var weaponSlot = EquipSlotConverter.EquipSlotToWeaponSlot(equipSlot);
-        Character->DrawData.LoadWeapon(weaponSlot, weaponModelId, 0, 0, 0, 0);
+        Character->DrawData.LoadWeapon(weaponSlot, weaponModelId, 0, 0, 0, 0, false);
     }
 
     private EquipmentModelId GetEquipmentModelId(Item item, byte stain0Id, byte? stain1Id)

--- a/Collections/GlobalUsing.cs
+++ b/Collections/GlobalUsing.cs
@@ -17,6 +17,7 @@ global using Dalamud.Plugin.Services;
 global using Dalamud.Interface;
 global using Dalamud.Interface.Components;
 global using Dalamud.Game.Addon.Lifecycle;
+global using Dalamud.Game.DutyState;
 global using Dalamud.Bindings.ImGui;
 
 // Project

--- a/Collections/UI/Tabs/InstanceTab.cs
+++ b/Collections/UI/Tabs/InstanceTab.cs
@@ -17,7 +17,7 @@ public class InstanceTab : IDrawable
         Services.DutyState.DutyStarted += OnDutyStarted;
     }
 
-    public void OnDutyStarted(object sender, ushort arg)
+    public void OnDutyStarted(IDutyStateEventArgs args)
     {
         Dev.Log("Received DutyStarted event");
         hideObtainedCollectibles = Services.Configuration.AutoHideObtainedFromInstanceTab;

--- a/Collections/packages.lock.json
+++ b/Collections/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[14.0.2, )",
-        "resolved": "14.0.2",
-        "contentHash": "dQJeq+8eyHzra4Cg5eZ/3LAeS3/UpvvLriYJGSncMK9LqJ7Q4B6jwcOsxo3PfxVd15xj+IzVFxkPqIBmPQu8/w=="
+        "requested": "[15.0.0, )",
+        "resolved": "15.0.0",
+        "contentHash": "411vwC8/X8Z/sQ2TI6v3SvOn66xFPeOjFn3Zn+h0d3Ox2t1kFm66AhDvmx/qcMwVrR+Hidxj0dadpQ2dgyXMBQ=="
       },
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",


### PR DESCRIPTION
- Bumped the SDK version
- Use the actual names for Lumina sheet columns
- Cabinet.IsItemInCabinet is now uint by default ([FFXIVClientStructs 0d458b05](https://github.com/aers/FFXIVClientStructs/commit/0d458b05078377caf961a08f885f0bd4bc8b73f5))
- Use EquipRestriction.RowId ([EXDSchema #188](https://github.com/xivdev/EXDSchema/commit/7b373c90d2244b0491d74fa0f3dd2cab9f016bed)) 
- Added missing bool to DrawData.LoadWeapon
- DutyStarted now takes IDutyStateEventArgs
- Get LocalPlayer pointer from ObjectTable instead of ClientState