### PR TITLE
Add setting to toggle between checkmark and green borders for obtained items

### DIFF
--- a/Collections/Base/Configuration.cs
+++ b/Collections/Base/Configuration.cs
@@ -19,6 +19,8 @@ public class Configuration : IPluginConfiguration
     public bool ForceTryOn = false;
     // Changes left-click behaviour for glamour collections
     public bool SeparatePreviewAndApply = false;
+    // Use a green border to indicate obtained items instead of displaying a checkmark
+    public bool HighVisibilityObtained = false;
 
     public void Save()
     {

--- a/Collections/UI/Tabs/SettingsTab.cs
+++ b/Collections/UI/Tabs/SettingsTab.cs
@@ -11,6 +11,7 @@ public class SettingsTab : IDrawable
         onlyOpenIfUncollected = Services.Configuration.OnlyOpenIfUncollected;
         autoHideObtainedFromInstanceTab = Services.Configuration.AutoHideObtainedFromInstanceTab;
         excludedCollectionsFromInstanceTab = Services.Configuration.ExcludedCollectionsFromInstanceTab;
+        highVisibilityObtained = Services.Configuration.HighVisibilityObtained;
         collectionNames = Services.DataProvider.GetCollections().AsParallel().Select(col => col.Key).OrderBy((key) => key != GlamourCollectible.CollectionName).ThenBy(k => k).ToList();
     }
 
@@ -18,6 +19,7 @@ public class SettingsTab : IDrawable
     private bool separatePreviewAndApply;
     private bool onlyOpenIfUncollected;
     private bool autoHideObtainedFromInstanceTab;
+    private bool highVisibilityObtained;
     private List<string> showAdditionalTooltips;
     private List<string> excludedCollectionsFromInstanceTab;
     public void Draw()
@@ -33,6 +35,7 @@ public class SettingsTab : IDrawable
             Services.Configuration.AutoOpenInstanceTab = autoOpenInstanceTab;
             Services.Configuration.Save();
         }
+
         // padding to signify this is a sub-option for auto-open
         ImGui.InvisibleButton("padding", new Vector2(15, 1));
         ImGui.SameLine();
@@ -41,11 +44,19 @@ public class SettingsTab : IDrawable
             Services.Configuration.OnlyOpenIfUncollected = onlyOpenIfUncollected;
             Services.Configuration.Save();
         }
+
         if (ImGui.Checkbox("Auto hide obtained items from Instance tab", ref autoHideObtainedFromInstanceTab))
         {
             Services.Configuration.AutoHideObtainedFromInstanceTab = autoHideObtainedFromInstanceTab;
             Services.Configuration.Save();
         }
+
+        if (ImGui.Checkbox("Use green borders to indicate obtained items instead of checkmarks", ref highVisibilityObtained))
+        {
+            Services.Configuration.HighVisibilityObtained = highVisibilityObtained;
+            Services.Configuration.Save();
+        }
+
         ImGui.Text("Show additional item information for these collections");
         ImGui.BeginListBox("##collection-box-add-tooltips", new Vector2(300, 200));
         foreach (var collection in collectionNames)

--- a/Collections/UI/Widgets/CollectionWidget.cs
+++ b/Collections/UI/Widgets/CollectionWidget.cs
@@ -1,6 +1,3 @@
-using System.Drawing;
-using Dalamud.Interface.Colors;
-
 namespace Collections;
 
 public class CollectionWidget
@@ -270,8 +267,11 @@ public class CollectionWidget
     private unsafe void DrawItem(ICollectible collectible)
     {
         // for debouncing, prevents interaction and favorite at the same time.
-        bool interact = false;
-        bool debounce = false;
+        var interact = false;
+        var debounce = false;
+
+        // to show red/green border instead of checkmark
+        var showObtainedBorders = Services.Configuration.HighVisibilityObtained;
 
         // to properly draw everything
         var icon = collectible.GetIcon();
@@ -285,6 +285,21 @@ public class CollectionWidget
         {
             interact = true;
         }
+
+
+        if (showObtainedBorders)
+        {
+            var obtainedColor = collectible.GetIsObtained() ? ColorsPalette.LIME_GREEN : ColorsPalette.RED;
+
+            // offset to compensate the frame padding 
+            const float borderOffset = 2f;
+            var min = ImGui.GetItemRectMin() + new Vector2(borderOffset, borderOffset);
+            var max = ImGui.GetItemRectMax() - new Vector2(borderOffset, borderOffset);
+
+            // Draw border
+            ImGui.GetWindowDrawList().AddRect(min, max, ImGui.ColorConvertFloat4ToU32(obtainedColor), 8f, ImDrawFlags.None, 2f);
+        }
+
 
         // Details on hover
         if (ImGui.IsItemHovered())
@@ -346,12 +361,16 @@ public class CollectionWidget
                 }
             }
         }
-        
-        // Mimicks the official FFXIV Yellow checkmark
-        var obtained = collectible.GetIsObtained();
-        // color
-        // UiHelper.IconButtonWithOffset(drawItemCount, FontAwesomeIcon.Check, iconSize, 0, ref obtained, 1.0f, new Vector4(1f, .741f, .188f, 1), ColorsPalette.BLACK.WithAlpha(0));
-        UiHelper.IconButtonWithOffset(drawItemCount, FontAwesomeIcon.Check, ImGui.GetStyle().ItemSpacing.X * 2 + ImGui.GetFontSize(), -iconSizeScaled + ImGui.GetFontSize(), ref obtained, 1.0f, new Vector4(1f, .741f, .188f, 1), ColorsPalette.BLACK.WithAlpha(0));
+
+        // Checkmark
+        if (!showObtainedBorders)
+        {
+            // Mimicks the official FFXIV Yellow checkmark
+            var obtained = collectible.GetIsObtained();
+            // color
+            // UiHelper.IconButtonWithOffset(drawItemCount, FontAwesomeIcon.Check, iconSize, 0, ref obtained, 1.0f, new Vector4(1f, .741f, .188f, 1), ColorsPalette.BLACK.WithAlpha(0));
+            UiHelper.IconButtonWithOffset(drawItemCount, FontAwesomeIcon.Check, ImGui.GetStyle().ItemSpacing.X * 2 + ImGui.GetFontSize(), -iconSizeScaled + ImGui.GetFontSize(), ref obtained, 1.0f, new Vector4(1f, .741f, .188f, 1), ColorsPalette.BLACK.WithAlpha(0));
+        }
     }
 
     private int GetIconsPerRow()

--- a/Collections/Utils/UiHelper.cs
+++ b/Collections/Utils/UiHelper.cs
@@ -15,6 +15,7 @@ public class ColorsPalette
     public static readonly Vector4 BLUE = new(0.344f, 0.436f, 0.960f, 0.786f);
     public static readonly Vector4 GREEN = new(0.008f, 0.593f, 0.140f, 0.5f);
     public static readonly Vector4 RED = new(0.719f, 0.109f, 0.109f, 0.9f);
+    public static readonly Vector4 LIME_GREEN = new Vector4(0f, 1f, 0f, 1f);
 }
 
 public class UiHelper


### PR DESCRIPTION
Some QoL improvements to make it easier to identify obtained items, especially on colorful icons.
Default is still `false`

Settings: 
<img width="456" height="176" alt="image" src="https://github.com/user-attachments/assets/975be9bc-6abe-4c9c-a147-e51046df351d" />
---
Before:
<img width="1201" height="890" alt="image" src="https://github.com/user-attachments/assets/e8a6f483-c7ab-48d1-8583-9be1013ebff6" />

After:
<img width="1205" height="889" alt="image" src="https://github.com/user-attachments/assets/22817968-1639-450d-b056-83b013734381" />
---
Before:
<img width="1203" height="891" alt="image" src="https://github.com/user-attachments/assets/0bb297ee-0d7b-4215-a169-6f32d7dc53e9" />

After:
<img width="1200" height="891" alt="image" src="https://github.com/user-attachments/assets/8ced1733-452d-4d93-a833-a5019533abf9" />
---
Before:
<img width="1198" height="892" alt="image" src="https://github.com/user-attachments/assets/b1f0b6c6-523e-4a89-ac61-831811871908" />

After:
<img width="1197" height="890" alt="image" src="https://github.com/user-attachments/assets/cce77f34-6797-4d1e-ab91-48d5333a3582" />
---
Before:
<img width="1201" height="892" alt="image" src="https://github.com/user-attachments/assets/e0c746b0-fa5b-4e91-8079-085e0ea461de" />

After:
<img width="1201" height="888" alt="image" src="https://github.com/user-attachments/assets/0086fc09-eb84-4c70-946f-2874daccc80b" />


