### PR TITLE
Add Triad Npc page

### DIFF
--- a/.idea/.idea.Collections/.idea/indexLayout.xml
+++ b/.idea/.idea.Collections/.idea/indexLayout.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="UserContentModel">
-    <attachedFolders />
-    <explicitIncludes />
-    <explicitExcludes />
-  </component>
-</project>

--- a/.idea/.idea.Collections/.idea/indexLayout.xml
+++ b/.idea/.idea.Collections/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/Collections/Base/Services.cs
+++ b/Collections/Base/Services.cs
@@ -18,6 +18,7 @@ public class Services
     [PluginService] public static ITextureProvider TextureProvider { get; private set; }
     [PluginService] public static IDutyState DutyState { get; private set; }
     [PluginService] public static IAddonLifecycle AddonLifecycle { get; private set; }
+    [PluginService] public static ISigScanner SigScanner { get; private set; }
 
     public static Plugin Plugin { get; private set; }
     public static Configuration Configuration { get; private set; }

--- a/Collections/Collectibles/Collectible/TripleTriadNpcCollectible.cs
+++ b/Collections/Collectibles/Collectible/TripleTriadNpcCollectible.cs
@@ -1,5 +1,3 @@
-using System.Text;
-
 namespace Collections.Collectibles.Collectible
 {
     public class TripleTriadNpcCollectible : Collectible<Lumina.Excel.Sheets.ENpcResident>, ICreateable<TripleTriadNpcCollectible, Lumina.Excel.Sheets.ENpcResident>
@@ -49,6 +47,8 @@ namespace Collections.Collectibles.Collectible
 
         protected override decimal GetPatchAdded()
         {
+            // This is guessing Patch based on map expansion.
+            // todo better approach for retrieving Triad NPC quest
             return GetLocation()?.TerritoryType.ExVersion.RowId switch
             {
                 0 => 2.0m,
@@ -77,7 +77,7 @@ namespace Collections.Collectibles.Collectible
             foreach (var npcData in npc.ENpcData)
             {
                 var tripleTriad = tripleTriadSheet.GetRow(npcData.RowId);
-                if (!tripleTriad.HasValue || tripleTriad.Value.Fee == 0)
+                if (!tripleTriad.HasValue)
                 {
                     continue;
                 }
@@ -98,10 +98,65 @@ namespace Collections.Collectibles.Collectible
             return tt.Value;
         }
 
+        private IEnumerable<Quest> GetRequiredQuests()
+        {
+            var tripleTriad = GetTripleTriad();
+            if (tripleTriad is null)
+            {
+                yield break;
+            }
+
+            foreach (var quest in tripleTriad.Value.PreviousQuest)
+            {
+                if (quest.RowId == 0)
+                {
+                    continue;
+                }
+
+                yield return quest.Value;
+            }
+        }
+
         private Location? GetLocation()
         {
             var hasValue = Services.DataGenerator.NpcLocationDataGenerator.npcToLocation.TryGetValue(ExcelRow.RowId, out var location);
             return hasValue ? location : null;
+        }
+
+        public override void DrawAdditionalTooltip()
+        {
+            var location = GetLocation();
+            var quests = GetRequiredQuests().ToList();
+
+            if (ImGui.BeginTable($"##tt-npc-{ExcelRow.RowId}-additional-tooltip", 2, ImGuiTableFlags.NoHostExtendX))
+            {
+                ImGui.TableSetupColumn("Label", ImGuiTableColumnFlags.WidthFixed, UiHelper.UnitWidth() * 14);
+                ImGui.TableSetupColumn("Value", ImGuiTableColumnFlags.WidthStretch);
+
+                if (location is not null)
+                {
+                    DrawTooltipRow("Map", location.TerritoryType.PlaceName.Value.Name.ToString());
+                    DrawTooltipRow("Location", $"X:{location.Xmap:F1} Y:{location.Ymap:F1}");
+                }
+
+                if (quests.Count > 0)
+                {
+                    DrawTooltipRow(quests.Count == 1 ? "Quest Req" : "Quests Req", string.Join("\n", quests.Select(quest => quest.Name.ToString())));
+                }
+
+                ImGui.EndTable();
+            }
+        }
+
+        private static void DrawTooltipRow(string label, string value)
+        {
+            ImGui.TableNextRow();
+            ImGui.TableNextColumn();
+            ImGui.TextColored(ColorsPalette.GREY2, label);
+            ImGui.TableNextColumn();
+            ImGui.PushTextWrapPos(UiHelper.UnitWidth() * 50);
+            ImGui.TextUnformatted(value);
+            ImGui.PopTextWrapPos();
         }
     }
 }

--- a/Collections/Collectibles/Collectible/TripleTriadNpcCollectible.cs
+++ b/Collections/Collectibles/Collectible/TripleTriadNpcCollectible.cs
@@ -1,0 +1,107 @@
+using System.Text;
+
+namespace Collections.Collectibles.Collectible
+{
+    public class TripleTriadNpcCollectible : Collectible<Lumina.Excel.Sheets.ENpcResident>, ICreateable<TripleTriadNpcCollectible, Lumina.Excel.Sheets.ENpcResident>
+    {
+        public new static string CollectionName => "Triad NPC";
+
+        public TripleTriadNpcCollectible(ENpcResident excelRow) : base(excelRow)
+        {
+        }
+
+        public override void UpdateObtainedState()
+        {
+
+            isObtained = TripleTriadNpcStateProvider.Instance.IsNpcBeaten((int)Id);
+        }
+
+        protected override string GetCollectionName()
+        {
+            return CollectionName;
+        }
+
+        public override void Interact()
+        {
+            //Nothing
+        }
+
+        protected override int GetIconId()
+        {
+            return TripleTriadNpcStateProvider.Instance.IsNpcBeaten((int)Id) ? 71302 : 71301;
+        }
+
+        protected override uint GetId()
+        {
+            var tripleTriad = GetTripleTriad();
+            return tripleTriad?.RowId ?? ExcelRow.RowId;
+        }
+
+        protected override string GetName()
+        {
+            return ExcelRow.Singular.ToString();
+        }
+
+        protected override string GetDescription()
+        {
+            return "";
+        }
+
+        protected override decimal GetPatchAdded()
+        {
+            return GetLocation()?.TerritoryType.ExVersion.RowId switch
+            {
+                0 => 2.0m,
+                1 => 3.0m,
+                2 => 4.0m,
+                3 => 5.0m,
+                4 => 6.0m,
+                5 => 7.0m,
+                _ => base.GetPatchAdded(),
+            };
+        }
+
+        public static TripleTriadNpcCollectible Create(ENpcResident excelRow)
+        {
+            return new(excelRow);
+        }
+
+        private ENpcBase? GetNpcBase()
+        {
+            return ExcelCache<ENpcBase>.GetSheet().GetRow(ExcelRow.RowId);
+        }
+
+        private TripleTriad? GetTripleTriadByNpc(ENpcBase npc)
+        {
+            var tripleTriadSheet = ExcelCache<TripleTriad>.GetSheet();
+            foreach (var npcData in npc.ENpcData)
+            {
+                var tripleTriad = tripleTriadSheet.GetRow(npcData.RowId);
+                if (!tripleTriad.HasValue || tripleTriad.Value.Fee == 0)
+                {
+                    continue;
+                }
+
+                return tripleTriad.Value;
+            }
+            return null;
+        }
+
+        private TripleTriad? GetTripleTriad()
+        {
+            var npc = GetNpcBase();
+            if (npc == null) return null;
+
+            var tt = GetTripleTriadByNpc(npc.Value);
+            if (tt == null) return null;
+
+            return tt.Value;
+        }
+
+        private Location? GetLocation()
+        {
+            var hasValue = Services.DataGenerator.NpcLocationDataGenerator.npcToLocation.TryGetValue(ExcelRow.RowId, out var location);
+            return hasValue ? location : null;
+        }
+    }
+}

--- a/Collections/Collectibles/CollectibleKey/CollectibleKeyFactory.cs
+++ b/Collections/Collectibles/CollectibleKey/CollectibleKeyFactory.cs
@@ -60,6 +60,13 @@ public class CollectibleKeyFactory
                 return new MonsterKey((monster, false));
             }
         }
+
+        if (type == typeof(ENpcResident))
+        {
+            var npc = (ENpcResident)(object)collectible.ExcelRow;
+            return CollectibleKeyCache<TripleTriadNpcKey, ENpcResident>.Instance.GetObject((npc, (int)id));
+        }
+
         return null;
     }
 }

--- a/Collections/Collectibles/CollectibleKey/TripleTriadNpcKey.cs
+++ b/Collections/Collectibles/CollectibleKey/TripleTriadNpcKey.cs
@@ -1,0 +1,38 @@
+namespace Collections;
+
+public class TripleTriadNpcKey : CollectibleKey<(ENpcResident, int)>, ICreateable<TripleTriadNpcKey, (ENpcResident, int)>
+{
+    public TripleTriadNpcKey((ENpcResident, int) input) : base(input)
+    {
+    }
+
+    public static TripleTriadNpcKey Create((ENpcResident, int) input)
+    {
+        return new(input);
+    }
+
+    protected override string GetName((ENpcResident, int) input)
+    {
+        return input.Item1.Singular.ToString();
+    }
+
+    protected override uint GetId((ENpcResident, int) input)
+    {
+        return input.Item2 == 0 ? input.Item1.RowId : (uint)input.Item2;
+    }
+
+    protected override List<ICollectibleSource> GetCollectibleSources((ENpcResident, int) input)
+    {
+        return new List<ICollectibleSource>() { new NpcSource(input.Item1) };
+    }
+
+    protected override HashSet<SourceCategory> GetBaseSourceCategories()
+    {
+        return new HashSet<SourceCategory>();
+    }
+
+    public override Tradeability GetIsTradeable()
+    {
+        return Tradeability.Untradeable;
+    }
+}

--- a/Collections/Data/Generators/Sources/TripleTriadNpcBattleDataGenerator.cs
+++ b/Collections/Data/Generators/Sources/TripleTriadNpcBattleDataGenerator.cs
@@ -1,0 +1,39 @@
+namespace Collections;
+
+// TripleTriadDataGenerator = Used for Triple Triad Collectible Source Lookup 
+// TripleTriadNpcBattleDataGenerator = Used for tracking TT Npc for achievement tracking in `Triad Npc`
+public class TripleTriadNpcBattleDataGenerator : BaseDataGenerator<ENpcResident>
+{
+    protected override void InitializeData()
+    {
+        var npcBases = ExcelCache<ENpcBase>.GetSheet();
+        var npcResidents = ExcelCache<ENpcResident>.GetSheet();
+        var tripleTriads = ExcelCache<TripleTriad>.GetSheet();
+
+        // Fee != 0 removes duplicate/invalid Triple Triad NPC rows.
+        var triadIds = tripleTriads
+                       .Where(x => x.Fee != 0)
+                       .Select(x => x.RowId)
+                       .ToHashSet();
+
+        foreach (var npc in npcBases)
+        {
+            var triadId = npc.ENpcData
+                             .Select(x => x.RowId)
+                             .FirstOrDefault(triadIds.Contains);
+
+            if (triadId == 0)
+                continue;
+
+            var resident = npcResidents.GetRow(npc.RowId);
+            var triad = tripleTriads.GetRow(triadId);
+
+            if (!resident.HasValue || !triad.HasValue)
+                continue;
+
+            AddEntry(triadId, resident.Value);
+            triadIds.Remove(triadId);
+        }
+    }
+}
+

--- a/Collections/Data/Generators/Sources/TripleTriadNpcBattleDataGenerator.cs
+++ b/Collections/Data/Generators/Sources/TripleTriadNpcBattleDataGenerator.cs
@@ -1,6 +1,6 @@
 namespace Collections;
 
-// TripleTriadDataGenerator = Used for Triple Triad Collectible Source Lookup 
+// TripleTriadNpcDataGenerator = Used for Triple Triad Collectible Source Lookup 
 // TripleTriadNpcBattleDataGenerator = Used for tracking TT Npc for achievement tracking in `Triad Npc`
 public class TripleTriadNpcBattleDataGenerator : BaseDataGenerator<ENpcResident>
 {

--- a/Collections/Data/Generators/SourcesDataGenerator.cs
+++ b/Collections/Data/Generators/SourcesDataGenerator.cs
@@ -12,6 +12,7 @@ public class SourcesDataGenerator
     public QuestsDataGenerator QuestsDataGenerator { get; private set; }
     public CraftingDataGenerator CraftingDataGenerator { get; private set; }
     public TripleTriadNpcDataGenerator TripleTriadNpcDataGenerator { get; private set; }
+    public TripleTriadNpcBattleDataGenerator TripleTriadNpcBattleDataGenerator { get; private set; }
     public SubmarineDataGenerator SubmarineDataGenerator {get; private set; }
 
     public SourcesDataGenerator()
@@ -31,6 +32,7 @@ public class SourcesDataGenerator
         var PvPDataGeneratorTask = Task.Run(() => new PvPSeriesDataGenerator());
         var CraftingDataGeneratorTask = Task.Run(() => new CraftingDataGenerator());
         var TripleTriadNpcDataGeneratorTask = Task.Run(() => new TripleTriadNpcDataGenerator());
+        var TripleTriadNpcBattleDataGeneratorTask = Task.Run(() => new TripleTriadNpcBattleDataGenerator());
         var SubmarineDataGeneratorTask = Task.Run(() => new SubmarineDataGenerator());
 
         ShopsDataGenerator = await ShopsDataGeneratorTask;
@@ -43,6 +45,7 @@ public class SourcesDataGenerator
         PvPDataGenerator = await PvPDataGeneratorTask;
         CraftingDataGenerator = await CraftingDataGeneratorTask;
         TripleTriadNpcDataGenerator = await TripleTriadNpcDataGeneratorTask;
+        TripleTriadNpcBattleDataGenerator = await TripleTriadNpcBattleDataGeneratorTask;
         SubmarineDataGenerator = await SubmarineDataGeneratorTask;
     }
 }

--- a/Collections/Data/Providers/DataProvider.cs
+++ b/Collections/Data/Providers/DataProvider.cs
@@ -153,9 +153,8 @@ public class DataProvider
     {
         collections[typeof(TripleTriadNpcCollectible)] = (
             TripleTriadNpcCollectible.CollectionName,
-            5,
-            Services.DataGenerator.SourcesDataGenerator.TripleTriadNpcDataGenerator.data.SelectMany(c => c.Value)
-            .DistinctBy(entry => entry.RowId)
+            6,
+            Services.DataGenerator.SourcesDataGenerator.TripleTriadNpcBattleDataGenerator.data.SelectMany(c => c.Value)
             .Select(entry => (ICollectible)CollectibleCache<TripleTriadNpcCollectible, ENpcResident>.Instance.GetObject(entry))
             .ToList()
             );
@@ -165,7 +164,7 @@ public class DataProvider
     {
         collections[typeof(BardingCollectible)] = (
             BardingCollectible.CollectionName,
-            7,
+            8,
             ExcelCache<BuddyEquip>.GetSheet().AsParallel()
             .Where(entry => entry.Name != "" && !DataOverrides.IgnoreBardingId.Contains(entry.RowId))
             .Select(entry => (ICollectible)CollectibleCache<BardingCollectible, BuddyEquip>.Instance.GetObject(entry))
@@ -177,7 +176,7 @@ public class DataProvider
     {
         collections[typeof(BlueMageCollectible)] = (
             BlueMageCollectible.CollectionName,
-            6,
+            7,
             ExcelCache<Lumina.Excel.Sheets.Action>.GetSheet().AsParallel()
             .Where(entry => entry.ClassJob.RowId == 36 && entry.Name != "")
             .Select(entry => (ICollectible)CollectibleCache<BlueMageCollectible, Lumina.Excel.Sheets.Action>.Instance.GetObject(entry))
@@ -189,7 +188,7 @@ public class DataProvider
     {
         collections[typeof(OrchestrionCollectible)] = (
             OrchestrionCollectible.CollectionName,
-            8,
+            9,
             ExcelCache<Orchestrion>.GetSheet().AsParallel()
             .Where(entry => entry.Name != "" && entry.Name != "0")
             .Select(entry => (ICollectible)CollectibleCache<OrchestrionCollectible, Orchestrion>.Instance.GetObject(entry))
@@ -201,7 +200,7 @@ public class DataProvider
     {
         collections[typeof(OutfitsCollectible)] = (
             OutfitsCollectible.CollectionName,
-            9,
+            10,
             ExcelCache<Item>.GetSheet().AsParallel()
             .Where(entry => entry.LevelEquip >= 1)
             .Where(entry => entry.ItemUICategory.Value.RowId == 112)
@@ -214,7 +213,7 @@ public class DataProvider
     {
         collections[typeof(FramerKitCollectible)] = (
             FramerKitCollectible.CollectionName,
-            10,
+            11,
             ExcelCache<BannerCondition>.GetSheet().AsParallel()
             .Where(entry =>
                 (entry.UnlockType1 == 1 && entry.UnlockType2 == 2 && entry.PrerequisiteType == 0) || // Job Portraits
@@ -233,7 +232,7 @@ public class DataProvider
     {
         collections[typeof(FashionAccessoriesCollectible)] = (
             FashionAccessoriesCollectible.CollectionName,
-            11,
+            12,
             ExcelCache<Ornament>.GetSheet().AsParallel()
             .Where(entry => entry.Icon != 0 && !DataOverrides.IgnoreFashionAccessoryId.Contains(entry.RowId))
             .Select(entry => (ICollectible)CollectibleCache<FashionAccessoriesCollectible, Ornament>.Instance.GetObject(entry))
@@ -245,7 +244,7 @@ public class DataProvider
     {
         collections[typeof(GlassesCollectible)] = (
             GlassesCollectible.CollectionName,
-            12,
+            13,
             ExcelCache<Glasses>.GetSheet().AsParallel()
             .Where(entry => entry.Icon != 0 && entry.Name == entry.Style.Value.Name)
             .Select(entry => (ICollectible)CollectibleCache<GlassesCollectible, Glasses>.Instance.GetObject(entry))

--- a/Collections/Data/Providers/DataProvider.cs
+++ b/Collections/Data/Providers/DataProvider.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Collections.Collectibles.Collectible;
 
 namespace Collections;
 
@@ -64,6 +65,7 @@ public class DataProvider
         InitializeEmoteCollection();
         InitializeHairstyleCollection();
         InitializeTripleTriadCollection();
+        InitializeTripleTriadNpcCollection();
         InitializeBlueMageCollection();
         InitializeBardingCollection();
         InitializeOrchestrionRollCollection();
@@ -147,6 +149,18 @@ public class DataProvider
             );
     }
 
+    private void InitializeTripleTriadNpcCollection()
+    {
+        collections[typeof(TripleTriadNpcCollectible)] = (
+            TripleTriadNpcCollectible.CollectionName,
+            5,
+            Services.DataGenerator.SourcesDataGenerator.TripleTriadNpcDataGenerator.data.SelectMany(c => c.Value)
+            .DistinctBy(entry => entry.RowId)
+            .Select(entry => (ICollectible)CollectibleCache<TripleTriadNpcCollectible, ENpcResident>.Instance.GetObject(entry))
+            .ToList()
+            );
+    }
+
     private void InitializeBardingCollection()
     {
         collections[typeof(BardingCollectible)] = (
@@ -226,6 +240,7 @@ public class DataProvider
             .ToList()
             );
     }
+
     private void InitializeGlassesCollection()
     {
         collections[typeof(GlassesCollectible)] = (

--- a/Collections/Data/Providers/TripleTriadNpcStateProvider.cs
+++ b/Collections/Data/Providers/TripleTriadNpcStateProvider.cs
@@ -1,0 +1,49 @@
+using System.Runtime.InteropServices;
+
+namespace Collections;
+
+public class TripleTriadNpcStateProvider
+{
+    private const int MinimumTriadNpcId = 0x230002;
+    private const string IsNpcBeatenSignature = "40 53 48 83 ec 20 8d 82 fe ff dc ff";
+    private const string TriadUiStateSignature = "48 8d 0d ?? ?? ?? ?? e8 ?? ?? ?? ?? 84 c0 74 0f 8b cb";
+
+    public static TripleTriadNpcStateProvider Instance { get; } = new();
+
+    private delegate byte IsNpcBeatenDelegate(IntPtr uiState, int triadNpcId);
+
+    private readonly IntPtr isNpcBeatenPtr;
+    private readonly IntPtr triadUiStatePtr;
+    private readonly IsNpcBeatenDelegate? isNpcBeatenFunc;
+
+    private TripleTriadNpcStateProvider()
+    {
+        try
+        {
+            // Services.UnlockState does not contain a method to retrieve IsNpcBeaten.
+            // Signature address credit to https://github.com/MgAl2O4/FFTriadBuddyDalamud/blob/main/plugin/UnsafeReaderTriadCards.cs
+            // This address remain const since launch of dawntrail as of may 2026
+            isNpcBeatenPtr = Services.SigScanner.ScanText(IsNpcBeatenSignature);
+            triadUiStatePtr = Services.SigScanner.GetStaticAddressFromSig(TriadUiStateSignature);
+
+            if (isNpcBeatenPtr != IntPtr.Zero && triadUiStatePtr != IntPtr.Zero)
+            {
+                isNpcBeatenFunc = Marshal.GetDelegateForFunctionPointer<IsNpcBeatenDelegate>(isNpcBeatenPtr);
+            }
+        }
+        catch (Exception ex)
+        {
+            Dev.Log($"Failed to initialize Triple Triad NPC state provider: {ex.Message}");
+        }
+    }
+
+    public bool IsNpcBeaten(int npcId)
+    {
+        if (isNpcBeatenPtr == IntPtr.Zero || triadUiStatePtr == IntPtr.Zero || npcId < MinimumTriadNpcId)
+        {
+            return false;
+        }
+
+        return isNpcBeatenFunc != null && isNpcBeatenFunc(triadUiStatePtr, npcId) != 0;
+    }
+}


### PR DESCRIPTION
Add new page to track unique defeated NPCs at Triple Triad for `Triple Team` achievements and `Magicked Card` mount

Features:
- Track unique NPCs defeated in TT battles
- Show NPC locations using markers
- Show required questlines to unlock TT battle

Preview: 
<img width="1407" height="855" alt="image" src="https://github.com/user-attachments/assets/51c8947e-094f-4fc9-825d-3922f6c8edcb" />
<img width="600" height="398" alt="image" src="https://github.com/user-attachments/assets/1dd05fd0-18e6-4765-a936-6ddd6fd919a7" />


Related Achievements: 
<img width="846" height="533" alt="image" src="https://github.com/user-attachments/assets/b7cb58e3-8ed8-4080-ac29-68a524503c50" />
<img width="856" height="594" alt="image" src="https://github.com/user-attachments/assets/489209a7-1ba9-4a06-b65b-52df8e124cda" />

Mount:
<img width="530" height="298" alt="image" src="https://github.com/user-attachments/assets/ba6d2991-3ad9-463e-b0f3-fe1c34801402" />
